### PR TITLE
setting: 모니터링을 위한 Actuator 및 exporter 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ dependencies {
 
     // Observability
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 
     // Build-time tools
     compileOnly        'org.projectlombok:lombok'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,21 @@
 version: '3.9'
 services:
+  spring:
+    image: homesweet-backend
+    container_name: homesweet-backend
+    ports:
+      - "8080:8080"
+    env_file:
+      - .env
+    environment:
+      - SPRING_PROFILES_ACTIVE=dev
+    networks:
+      - homesweet-network
+    depends_on:
+      - db
   db:
     image: mysql:8.0
+    container_name: homesweet-db
     environment:
       MYSQL_ROOT_PASSWORD: rootpassword
       MYSQL_DATABASE: homesweet
@@ -11,6 +25,31 @@ services:
       - "3306:3306"
     volumes:
       - mysqldata:/var/lib/mysql
+    networks:
+      - homesweet-network
 
+  node_exporter:
+    image: prom/node-exporter:latest
+    container_name: node_exporter
+    restart: always
+    ports:
+      - "9100:9100"
+
+  mysqld_exporter:
+    image: prom/mysqld-exporter:latest
+    container_name: mysqld_exporter
+    restart: always
+    command:
+      - "--mysqld.username=user:password"
+      - "--mysqld.address=mysql:3306"
+    ports:
+      - "9104:9104"
+    networks:
+      - homesweet-network
+
+
+networks:
+  homesweet-network:
+    driver: bridge
 volumes:
   mysqldata:

--- a/monitoring.sh
+++ b/monitoring.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# ===== Config =====
+# 사설망 CIDR (예: 가정/사무실 일반 환경)
+# 필요 시 10.0.0.0/8, 172.16.0.0/12 등으로 변경하세요
+CIDR="172.16.0.0/12"
+PORTS=("9100" "9104" "8080")
+BACKUP="/etc/pf.conf.backup.$(date +%Y%m%d%H%M%S)"
+
+# ===== UI Helpers =====
+BLUE="\033[1;34m"
+GREEN="\033[1;32m"
+YELLOW="\033[1;33m"
+RED="\033[1;31m"
+GRAY="\033[0;37m"
+NC="\033[0m"
+
+CHECK="✅"
+ARROW="➜"
+WARN="⚠️"
+CROSS="❌"
+
+section() {
+  echo ""
+  echo -e "${BLUE}==== $1 ====${NC}"
+}
+
+info() {
+  echo -e "${GRAY}${ARROW} $1${NC}"
+}
+
+success() {
+  echo -e "${GREEN}${CHECK} $1${NC}"
+}
+
+warn() {
+  echo -e "${YELLOW}${WARN} $1${NC}"
+}
+
+error_exit() {
+  echo -e "${RED}${CROSS} $1${NC}"
+  exit 1
+}
+
+section "PF 방화벽 규칙 적용 (CIDR: ${CIDR}, Ports: ${PORTS[*]})"
+
+section "백업"
+info "/etc/pf.conf -> ${BACKUP}"
+sudo cp /etc/pf.conf "${BACKUP}"
+success "백업 완료"
+
+section "룰 삽입 여부 확인"
+info "포트별로 필요한 규칙만 추가합니다"
+
+MISSING_RULES=""
+for port in "${PORTS[@]}"; do
+  # allow rule: pass from CIDR to port
+  if ! grep -qE "^pass in proto tcp from ${CIDR} to any port ${port}(\s|$)" /etc/pf.conf; then
+    MISSING_RULES+=$'pass in proto tcp from '${CIDR}' to any port '${port}' # monitoring allow local network\n'
+  fi
+  # block rule: block external to port
+  # 내부망 외의 소스만 차단하도록 from ! CIDR 사용
+  if ! grep -qE "^block in proto tcp from ! ${CIDR} to any port ${port}(\s|$)" /etc/pf.conf; then
+    MISSING_RULES+=$'block in proto tcp from ! '${CIDR}' to any port '${port}' # monitoring block external (not in CIDR)\n'
+  fi
+done
+
+if [[ -n "${MISSING_RULES}" ]]; then
+  # 루프백(127.0.0.1) 예외: localhost 접근은 항상 허용
+  SKIP_LO0=""
+  if ! grep -qE "^set skip on lo0(\s|$)" /etc/pf.conf; then
+    SKIP_LO0=$'set skip on lo0\n'
+  fi
+  info "부족한 규칙을 /etc/pf.conf에 추가합니다"
+  sudo bash -c "cat >> /etc/pf.conf" <<EOF
+
+# monitoring access control (Added by monitoring.sh)
+${SKIP_LO0%$'\n'}
+${MISSING_RULES%$'\n'}
+# end of monitoring rules
+EOF
+  success "부족한 규칙 추가 완료"
+else
+  warn "추가할 규칙이 없습니다. 모든 포트 규칙이 이미 존재합니다."
+fi
+
+section "pf.conf 문법 검사"
+if ! sudo pfctl -nf /etc/pf.conf; then
+  warn "문법 오류 감지. 백업본으로 복구합니다: ${BACKUP}"
+  sudo cp "${BACKUP}" /etc/pf.conf || error_exit "백업 복구 실패"
+  exit 1
+fi
+success "문법 정상"
+
+section "룰 적용 및 PF 활성화"
+info "pfctl -f /etc/pf.conf"
+sudo pfctl -f /etc/pf.conf
+info "pfctl -e (이미 활성화되어 있으면 무시됨)"
+sudo pfctl -e || true
+success "PF 적용/활성화 완료"
+
+section "적용 결과 확인"
+info "9100/9104/8080 관련 룰 요약"
+sudo pfctl -sr | egrep '9100|9104|8080' || true
+success "완료"

--- a/src/main/java/com/homesweet/homesweetback/common/config/SecurityConfig.java
+++ b/src/main/java/com/homesweet/homesweetback/common/config/SecurityConfig.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -69,7 +68,9 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/api/v1/healthz",
-                                "/actuator/health",
+                                        "/actuator/health",
+                                        "/actuator/info",
+                                        "/actuator/prometheus",
                                 "/v3/api-docs/**",
                                 "/swagger-ui/**",
                                 "/swagger-ui.html",

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -7,10 +7,10 @@ spring:
   config:
     import: optional:file:.env[.properties]
   datasource:
-    url: jdbc:mysql://localhost:3306/homesweet
-    username: user
-    password: password
+    url: ${DATABASE_URL:jdbc:mysql://localhost:3306/homesweet}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    username: ${DATABASE_USERNAME:user}
+    password: ${DATABASE_PASSWORD:password}
   jpa:
     hibernate:
       ddl-auto: none
@@ -71,3 +71,19 @@ log:
 payments:
   toss:
     secretKey: ${TOSS_PAYMENTS_SECRET_KEY:example-secret-key}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics,prometheus
+  endpoint:
+    health:
+      show-details: always
+  metrics:
+    tags:
+      application: homesweet-back
+  prometheus:
+    metrics:
+      export:
+        enabled: true

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -51,3 +51,19 @@ jwt:
   secret: ${JWT_SECRET}  # 필수 환경 변수
   access-token-expiration: 1800000   # 30분 (프로덕션에서는 짧게)
   refresh-token-expiration: 604800000 # 7일
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,prometheus
+  endpoint:
+    health:
+      show-details: never
+  metrics:
+    tags:
+      application: homesweet-back
+  prometheus:
+    metrics:
+      export:
+        enabled: true


### PR DESCRIPTION
## 구현 내용
Spring Boot Actuator와 Micrometer Prometheus 연동을 추가하고, 운영/개발 환경별 노출 엔드포인트와 보안 정책을 구성했습니다. 또한 노드/DB 메트릭 수집을 위한 Exporter 컨테이너와 로컬 방화벽(pf) 규칙 적용 스크립트를 추가했습니다.

### 구현된 API 엔드포인트
- GET /actuator/health - 헬스체크
- GET /actuator/info - 애플리케이션 정보 (dev만 노출)
- GET /actuator/prometheus - Prometheus 포맷 메트릭 노출

### 주요 변경사항
- build.gradle
  - spring-boot-starter-actuator, micrometer-registry-prometheus 의존성 추가
- application-dev.yml
  - management.endpoints.web.exposure: health, info, metrics, prometheus 노출
  - health 상세 always, Prometheus export 활성화, 공통 애플리케이션 태그 추가
- application-prod.yml
  - management.endpoints.web.exposure: health, prometheus 노출 최소화
  - health 상세 비노출(never), Prometheus export 활성화, 공통 태그 추가
- SecurityConfig.java
  - `/actuator/health`, `/actuator/info`, `/actuator/prometheus`, `/v3/api-docs/**`, `/swagger-ui/**` 등 접근 허용
  - `/api/v1/healthz` 경로도 permitAll 추가(엔드포인트는 추후 구현)
- docker-compose.yml
  - `prom/node-exporter`(9100), `prom/mysqld-exporter`(9104) 서비스 추가
- monitoring.sh
  - macOS pf 방화벽에 8080/9100/9104 포트에 대한 내부망 허용/외부 차단 규칙을 안전하게 삽입하는 스크립트 추가(백업 및 문법 검사 포함)

## 테스트 완료 사항
- [ ] 단위 테스트
- [ ] 통합 테스트
- [ ] API 테스트 (Swagger/Postman 등)
- [ ] 기타 테스트

## 스크린샷
<!-- 필요한 경우 관련 스크린샷을 첨부해주세요 -->

## 관련 이슈
closes #65
