### PR TITLE
refactor/86: 장바구니, 결제, 주문 상세 수정

### DIFF
--- a/src/main/java/com/homesweet/homesweetback/common/exception/ErrorCode.java
+++ b/src/main/java/com/homesweet/homesweetback/common/exception/ErrorCode.java
@@ -42,6 +42,7 @@ public enum ErrorCode {
     CART_LIMIT_EXCEEDED_ERROR(HttpStatus.BAD_REQUEST, "장바구니에는 최대 10개 제품만 담을 수 있습니다"),
     CART_ITEM_TYPE_LIMIT_EXCEEDED_ERROR(HttpStatus.BAD_REQUEST,"장바구니에는 최대 10개 종류의 상품만 담을 수 있습니다."),
     PRODUCT_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "해당하는 제품을 찾을 수 없습니다"),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "유효하지 않은 입력값입니다."),
 
     // Community
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 사용자를 찾을 수 없습니다"),

--- a/src/main/java/com/homesweet/homesweetback/domain/order/service/OrderService.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/order/service/OrderService.java
@@ -146,34 +146,49 @@ public class OrderService {
     }
 
     public List<MyOrderItemResponse> getMyOrders(Long userId) {
-        // 1. 사용자 조회
+        // 1. 사용자(User) 조회
         User user = userRepository.findById(userId).orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다: " + userId));
+
         // 2. 주문 목록 조회 (N+1 방지용 쿼리 사용)
         List<Order> orders = orderRepository.findAllByUserWithDetails(user);
+
         // 3. MyOrderItemResponse DTO 리스트로 변환
         return orders.stream().map(order -> {
-                    // 3-1. 대표 상품 찾기
-                    OrderItem representativeItem = order.getOrderItems().stream().findFirst().orElse(null);
 
                     String productName = "주문 항목 없음";
-                    String imageUrl = "";
-                    Long price = 0L; // 대표 상품 단가
+                    String imageUrl = ""; // 기본 이미지 URL
 
-                    if (representativeItem != null) {
+                    List<OrderItem> orderItems = order.getOrderItems();
+
+                    if (orderItems != null && !orderItems.isEmpty()) {
+                        // 3-1. 대표 상품(첫 번째 OrderItem) 정보 가져오기
+                        OrderItem representativeItem = orderItems.get(0);
                         ProductEntity product = representativeItem.getSku().getProduct();
-                        productName = product.getName();
-                        imageUrl = product.getImageUrl();
-                        price = representativeItem.getPrice();
+
+                        imageUrl = product.getImageUrl(); // (결정 1) 이미지는 대표 상품 1개
+
+                        // 3-2. (수정) 상품명: "A상품 외 N건" 형식으로 조합
+                        String firstProductName = product.getName();
+                        int otherItemsCount = orderItems.size() - 1;
+
+                        if (otherItemsCount > 0) {
+                            productName = String.format("%s 외 %d건", firstProductName, otherItemsCount);
+                        } else {
+                            productName = firstProductName;
+                        }
                     }
 
-                    // 3-2. DTO 생성
+                    // 3-3. (수정) 가격: 주문의 '최종 결제 금액' 사용
+                    Long price = order.getTotalAmount(); // (결정 3)
+
+                    // 3-4. DTO 생성
                     return MyOrderItemResponse.builder()
                             .orderId(order.getId())
                             .orderNumber(order.generateOrderNumber())
                             .orderDate(order.getOrderedAt().format(DateTimeFormatter.ISO_LOCAL_DATE))
-                            .productName(productName)
-                            .imageUrl(imageUrl)
-                            .price(price)
+                            .productName(productName) // "A상품 외 1건"
+                            .imageUrl(imageUrl)       // "A상품 이미지"
+                            .price(price)             // "주문 총액"
                             .orderStatus(order.getOrderStatus().name())
                             .deliveryStatus(order.getDeliveryStatus().name())
                             .build();

--- a/src/main/java/com/homesweet/homesweetback/domain/product/cart/controller/CartController.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/product/cart/controller/CartController.java
@@ -8,11 +8,15 @@ import com.homesweet.homesweetback.domain.product.cart.controller.request.Delete
 import com.homesweet.homesweetback.domain.product.cart.controller.response.CartResponse;
 import com.homesweet.homesweetback.domain.product.cart.domain.Cart;
 import com.homesweet.homesweetback.domain.product.cart.service.CartService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+// 장바구니 수정 - 안채호
+import com.homesweet.homesweetback.domain.product.cart.controller.request.CartQuantityUpdateRequest;
 
 /**
  * 장바구니 컨트롤러
@@ -83,5 +87,19 @@ public class CartController {
         Long userId = principal.getUserId();
         service.deleteSelectedCartItems(userId, request.cartIds());
         return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/{cartId}")
+    public ResponseEntity<Void> updateCartItemQuantity(
+            @AuthenticationPrincipal OAuth2UserPrincipal principal,
+            @PathVariable Long cartId,
+            @Valid @RequestBody CartQuantityUpdateRequest request
+    ) {
+        Long userId = principal.getUserId();
+
+        // CartService의 새 메서드 호출
+        service.updateCartItemQuantity(userId, cartId, request.quantity());
+
+        return ResponseEntity.ok().build(); // 성공 (200 OK)
     }
 }

--- a/src/main/java/com/homesweet/homesweetback/domain/product/cart/controller/request/CartQuantityUpdateRequest.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/product/cart/controller/request/CartQuantityUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.homesweet.homesweetback.domain.product.cart.controller.request;
+
+import jakarta.validation.constraints.Min;
+
+public record CartQuantityUpdateRequest(
+        // CartServiceImpl에서 10개 초과를 막고 있으므로
+        // @Max(value = 10, message = "최대 10개까지 담을 수 있습니다.")
+        @Min(value = 1, message = "수량은 1개 이상이어야 합니다.")
+        int quantity
+) {
+}

--- a/src/main/java/com/homesweet/homesweetback/domain/product/cart/repository/CartRepository.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/product/cart/repository/CartRepository.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * 장바구니 레포 명세
+ * 장바구니 레포 명세s
  *
  * @author junnukim1007gmail.com
  * @date 25. 10. 24.
@@ -21,6 +21,8 @@ public interface CartRepository {
     Cart updateQuantity(Cart domain);
 
     List<CartResponse> findNextCartItems(Long memberId, Long cursorId, int size);
+
+    Optional<Cart> findById(Long cartId);
 
     boolean existsByIdAndUserId(Long cartId, Long userId);
 

--- a/src/main/java/com/homesweet/homesweetback/domain/product/cart/repository/impl/CartRepositoryImpl.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/product/cart/repository/impl/CartRepositoryImpl.java
@@ -29,6 +29,11 @@ public class CartRepositoryImpl implements CartRepository {
     private final CartJPARepository jpaRepository;
     private final CartMapper mapper;
 
+    @Override
+    public Optional<Cart> findById(Long cartId) {
+        return jpaRepository.findById(cartId)
+                .map(mapper::toDomain); // JPARepository로 엔티티를 찾아 도메인 객체로 변환
+    }
 
     @Override
     public Optional<Cart> findByUserIdAndSkuId(Long userId, Long skuId) {

--- a/src/main/java/com/homesweet/homesweetback/domain/product/cart/repository/jpa/querydsl/CustomCartRepositoryImpl.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/product/cart/repository/jpa/querydsl/CustomCartRepositoryImpl.java
@@ -32,7 +32,7 @@ public class CustomCartRepositoryImpl implements CustomCartRepository {
                 .select(cart.id)
                 .from(cart)
                 .where(buildCartCursorCondition(cart, memberId, cursorId))
-                .orderBy(cart.id.desc())
+                .orderBy(cart.id.asc()) // 오름차순으로 변경 했습니다~
                 .limit(size + 1)
                 .fetch();
 
@@ -62,7 +62,7 @@ public class CustomCartRepositoryImpl implements CustomCartRepository {
                 .leftJoin(optionValue).on(optionValue.eq(skuOption.optionValue))
                 .leftJoin(optionGroup).on(optionGroup.eq(optionValue.group))
                 .where(cart.id.in(cartIds))
-                .orderBy(cart.id.desc())
+                .orderBy(cart.id.asc()) // 오름차순으로 변경했습니다~ 2
                 .fetch();
 
         // 카트별로 옵션 병합
@@ -114,7 +114,7 @@ public class CustomCartRepositoryImpl implements CustomCartRepository {
     private BooleanExpression buildCartCursorCondition(QCartEntity cart, Long memberId, Long cursorId) {
         BooleanExpression condition = cart.user.id.eq(memberId);
         if (cursorId != null) {
-            condition = condition.and(cart.id.lt(cursorId));
+            condition = condition.and(cart.id.gt(cursorId)); // gt = greater than
         }
         return condition;
     }

--- a/src/main/java/com/homesweet/homesweetback/domain/product/cart/service/CartService.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/product/cart/service/CartService.java
@@ -24,4 +24,6 @@ public interface CartService {
     void deleteSelectedCartItems(Long userId, List<Long> cartIds);
 
     int getCartItemCount(Long userId);
+
+    void updateCartItemQuantity(Long userId, Long cartId, int quantity); // 장바구니 수정용 - 안채호
 }

--- a/src/main/java/com/homesweet/homesweetback/domain/product/cart/service/impl/CartServiceImpl.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/product/cart/service/impl/CartServiceImpl.java
@@ -96,6 +96,40 @@ public class CartServiceImpl implements CartService {
         return cartRepository.countByUserId(userId);
     }
 
+    // 장바구니 수량 변경용 - 안채호
+    @Override
+    @Transactional
+    public void updateCartItemQuantity(Long userId, Long cartId, int quantity) {
+
+        // 1. 수량 유효성 검사 (프론트에서 1로 막지만, 서버에서도 방어)
+        if (quantity <= 0) {
+            // (참고) 프론트엔드 cart/page.tsx는 수량이 0이 되면
+            // 이 메서드 대신 deleteCartItem을 호출하도록 되어있습니다.
+            // 하지만 비정상적인 0이하 값 요청은 막습니다.
+            throw new ProductException(ErrorCode.INVALID_INPUT_VALUE); // (적절한 에러 코드로 변경 필요)
+        }
+
+        // 2. 수량 10개 제한 체크 (addToCart와 동일한 정책 적용)
+        if (quantity > 10) {
+            throw new ProductException(ErrorCode.CART_LIMIT_EXCEEDED_ERROR);
+        }
+
+        // 3. 카트 항목이 사용자의 소유인지 검증 (기존 헬퍼 메서드 재사용)
+        validateExistsCart(cartId, userId);
+
+        // 4. 카트 정보 가져오기
+        Cart cart = cartRepository.findById(cartId)
+                .orElseThrow(() -> new ProductException(ErrorCode.CART_NOT_FOUND_ERROR));
+
+        // 5. Cart 도메인 객체의 수량 업데이트 메서드 호출
+        // (참고: CartEntity.updateQuantity가 quantity를 '설정'한다고 가정)
+        Cart updatedCartDomain = cart.updateQuantity(quantity);
+
+        // 6. Repository를 통해 DB에 수량 업데이트
+        // (참고: addToCart의 private updateQuantity와 동일한 방식)
+        cartRepository.updateQuantity(updatedCartDomain);
+    }
+
     private Cart updateQuantity(Cart cart, int additionalQuantity) {
         Cart domain = cart.updateQuantity(cart.quantity() + additionalQuantity);
         return cartRepository.updateQuantity(domain);
@@ -119,4 +153,6 @@ public class CartServiceImpl implements CartService {
             throw new ProductException(ErrorCode.CART_NOT_FOUND_ERROR);
         }
     }
+
+
 }


### PR DESCRIPTION
## 구현 내용
1. 제품 상세 페이지에서 옵션을 선택하지 않고 구매하기를 누르면 주문 생성이 거절되고 옵션을 선택하고 구매하면 주문 생성 되어, 장바구니 구매와 제품 페이지 구매 분기를 나눕니다.
2. 장바구니를 통해 결제 페이지에서 두 건이상의 주문을 넣어도 처음 넣은 대표 상품 한 건만 보이는 것을 모든 제품이 다 나오게 하였습니다.
3. 주문 상세 보기에서 두 가지 상품을 구매하면 마지막에 담은 제품 하나만 나온것을 모든 제품이 다 나오게 하였습니다.
4. 장바구니 페이지에서 수량을 변경하면 주문 목록이 위로 올라가고, 수량이 변경 될 때 마다 화면이 깜빡이는 것을 새로운 API를 만들어 주문 상품이 수량 변경을 하여도 제자리에 고정되고 화면 깜빡임을 없앴습니다.

### 구현된 API 엔드포인트
[PATCH] /api/v1/carts/{cartId}

## 테스트 완료 사항
<!-- 테스트한 항목에 체크(x)해주세요 -->
- [x] 단위 테스트
- [ ] 통합 테스트
- [ ] API 테스트 (Swagger/Postman 등)
- [ ] 기타 테스트

## 관련 이슈
closes #86 