### PR TITLE
hotfix: 상품 등록 시 디테일 이미지 추가하지 않아도 저장되도록 수정

### DIFF
--- a/src/main/java/com/homesweet/homesweetback/common/s3/impl/S3ImageUploader.java
+++ b/src/main/java/com/homesweet/homesweetback/common/s3/impl/S3ImageUploader.java
@@ -71,7 +71,7 @@ public class S3ImageUploader implements ImageUploader {
     @Override
     public List<String> uploadFiles(List<MultipartFile> files, String directory) {
         if (files == null || files.isEmpty()) {
-            throw new CustomS3Exception(ErrorCode.INVALID_FILE_ERROR);
+            return new ArrayList<>();
         }
 
         List<String> uploadedUrls = new ArrayList<>();

--- a/src/main/java/com/homesweet/homesweetback/domain/product/product/controller/request/create/ProductCreateRequest.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/product/product/controller/request/create/ProductCreateRequest.java
@@ -17,7 +17,7 @@ public record ProductCreateRequest(
         Long categoryId,
 
         @NotBlank(message = "제품명은 필수입니다.")
-        @Size(max = 30, message = "제품명은 30자 이내로 입력해주세요.")
+        @Size(max = 100, message = "제품명은 100자 이내로 입력해주세요.")
         String name,
 
         @NotBlank(message = "브랜드는 필수입니다.")

--- a/src/main/java/com/homesweet/homesweetback/domain/product/product/controller/request/update/ProductBasicInfoUpdateRequest.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/product/product/controller/request/update/ProductBasicInfoUpdateRequest.java
@@ -12,7 +12,7 @@ import java.math.BigDecimal;
  */
 public record ProductBasicInfoUpdateRequest(
 
-        @Size(max = 30, message = "제품명은 30자 이내로 입력해주세요.")
+        @Size(max = 100, message = "제품명은 100자 이내로 입력해주세요.")
         String name,
 
         @Size(max = 20, message = "브랜드는 20자 이내로 입력해주세요.")

--- a/src/main/java/com/homesweet/homesweetback/domain/product/product/service/impl/ProductServiceImpl.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/product/product/service/impl/ProductServiceImpl.java
@@ -134,8 +134,10 @@ public class ProductServiceImpl implements ProductService {
         Product product = productRepository.findByIdAndSellerId(sellerId, productId)
                 .orElseThrow(() -> new ProductException(ErrorCode.PRODUCT_NOT_FOUND_ERROR));
 
-        if (productRepository.existsBySellerIdAndName(sellerId, request.name())) {
-            throw new ProductException(ErrorCode.DUPLICATED_PRODUCT_NAME_ERROR);
+        if (request.name() != null && !request.name().equals(product.getName())) {
+            if (productRepository.existsBySellerIdAndName(sellerId, request.name())) {
+                throw new ProductException(ErrorCode.DUPLICATED_PRODUCT_NAME_ERROR);
+            }
         }
 
         Product update = product.update(request);


### PR DESCRIPTION
- 제품 기본 정보 수정 시 이름 변경하지 않아도 되도록 설정

## 구현 내용
<!-- 구현한 기능에 대한 간략한 설명을 작성해주세요 -->
- 기존 이름 변경하지 않았을 때 상품 정보가 수정되지 않는 버그를 수정하였습니다
- 상품명 수정 시 100자 이내로 수정하도록 변경하였습니다
- 상품 상세 이미지 없이 등록 가능하도록 수정했습니다

## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
closes #98