### PR TITLE
feat: 판매자 신청시 등급 자동 생성 및 알림

### DIFF
--- a/src/main/java/com/homesweet/homesweetback/domain/auth/controller/UserController.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/auth/controller/UserController.java
@@ -12,10 +12,10 @@ import jakarta.validation.Valid;
 import com.homesweet.homesweetback.domain.auth.dto.UpdateUserRequest;
 import com.homesweet.homesweetback.domain.auth.dto.UpdateUserRoleRequest;
 import com.homesweet.homesweetback.domain.auth.dto.UserResponse;
-import com.homesweet.homesweetback.domain.notification.domain.NotificationCategoryType;
+import com.homesweet.homesweetback.domain.notification.domain.NotificationEventType;
+import com.homesweet.homesweetback.domain.notification.domain.payload.SystemNotificationPayload;
 import com.homesweet.homesweetback.domain.notification.service.NotificationSendService;
 
-import java.util.Map;
 import java.util.Optional;
 
 import org.springframework.http.ResponseEntity;
@@ -62,14 +62,12 @@ public class UserController {
         UserResponse userResponse = userService.updateUserRole(userId, request);
 
         // 알림 전송
-        notificationSendService.sendCustomNotificationToSingleUser(
-            userId, 
-            NotificationCategoryType.CUSTOM, 
-            "판매자 등록 완료", 
-            "판매자 등록이 완료되었습니다.", 
-            "/user/seller", 
-            Map.of("userName", userResponse.name())
-        );
+        SystemNotificationPayload.SellerRegistrationCompletePayload payload = SystemNotificationPayload.SellerRegistrationCompletePayload.builder()
+            .userName(userResponse.name())
+            .build();
+
+        notificationSendService.sendTemplateNotificationToSingleUser(userId, NotificationEventType.SELLER_REGISTRATION_COMPLETE, payload);
+
         return ResponseEntity.ok(userResponse);
     }
 

--- a/src/main/java/com/homesweet/homesweetback/domain/auth/service/UserService.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/auth/service/UserService.java
@@ -5,12 +5,14 @@ import com.homesweet.homesweetback.domain.auth.dto.UpdateUserRoleRequest;
 import com.homesweet.homesweetback.domain.auth.dto.UserResponse;
 import com.homesweet.homesweetback.domain.auth.entity.User;
 import com.homesweet.homesweetback.domain.grade.entity.Grade;
+import com.homesweet.homesweetback.domain.grade.repository.GradeRepository;
 import com.homesweet.homesweetback.domain.auth.repository.UserRepository;
 import com.homesweet.homesweetback.common.util.PhoneNumberValidator;
 import com.homesweet.homesweetback.common.s3.ImageUploader;
 
 import java.math.BigDecimal;
 import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,6 +30,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final ImageUploader imageUploader;
+    private final GradeRepository gradeRepository;  
     /**
      * 사용자 정보 조회
      */
@@ -111,6 +114,13 @@ public class UserService {
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new RuntimeException("User not found with id: " + userId));
         user.setRole(request.role());
+        
+        // 판매자 등급 랜덤 설정
+        Integer gradeId = ThreadLocalRandom.current().nextInt(1, 6);
+        Grade grade = gradeRepository.findById(gradeId)
+            .orElseThrow(() -> new RuntimeException("Grade not found with id: " + gradeId));
+        user.setGrade(grade);
+        
         return UserResponse.of(userRepository.save(user));
     }
 

--- a/src/main/java/com/homesweet/homesweetback/domain/notification/domain/NotificationEventType.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/notification/domain/NotificationEventType.java
@@ -306,6 +306,18 @@ public enum NotificationEventType {
      * "{promotionName} 프로모션이 종료되었습니다."
      */
     PROMOTION_END("프로모션 종료", NotificationCategoryType.PROMOTION),
+
+    // ==================== 판매자 등록 완료 관련 ====================
+    /**
+     * 판매자 등록 완료 알림
+     * 
+     * 📋 필요한 contextData:
+     * - userName: String - 사용자 이름
+     * 
+     * 📝 Content 템플릿:
+     * "판매자 등록이 완료되었습니다."
+     */
+    SELLER_REGISTRATION_COMPLETE("판매자 등록 완료", NotificationCategoryType.SYSTEM),
     
     // ==================== 커스텀 알림 ====================
     /**

--- a/src/main/java/com/homesweet/homesweetback/domain/notification/domain/payload/SystemNotificationPayload.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/notification/domain/payload/SystemNotificationPayload.java
@@ -1,0 +1,34 @@
+package com.homesweet.homesweetback.domain.notification.domain.payload;
+
+import com.homesweet.homesweetback.domain.notification.domain.NotificationEventType;
+
+import lombok.Builder;
+
+import java.util.Map;
+
+public class SystemNotificationPayload {
+
+    /**
+     * 판매자 등록 완료 알림 Payload
+     * 
+     * 📋 필요한 contextData:
+     * - userName: String - 사용자 이름
+     */
+    @SupportsEventType(NotificationEventType.SELLER_REGISTRATION_COMPLETE)
+    @Builder
+    public static class SellerRegistrationCompletePayload extends NotificationPayload {
+        private String userName;
+        
+        @Override
+        public Map<String, Object> toMap() {
+            return Map.of("userName", userName);
+        }
+        
+        @Override
+        protected void validateRequiredFields() {
+            if (userName == null || userName.isBlank()) {
+                throw new IllegalArgumentException("userName is required for SELLER_REGISTRATION_COMPLETE notification");
+            }
+        }
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -7,10 +7,10 @@ spring:
   config:
     import: optional:file:.env[.properties]
   datasource:
-    url: ${DATABASE_URL:jdbc:mysql://localhost:3306/homesweet}
+    url: jdbc:mysql://localhost:3306/homesweet
     driver-class-name: com.mysql.cj.jdbc.Driver
-    username: ${DATABASE_USERNAME:user}
-    password: ${DATABASE_PASSWORD:password}
+    username: user
+    password: password
   jpa:
     hibernate:
       ddl-auto: none

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     name: homesweet-back
   profiles:
     active:
-      - prod
+      - dev
   flyway:
     enabled: true
     baseline-on-migrate: true

--- a/src/main/resources/db/migration/V1.0.11__update_notification_templates.sql
+++ b/src/main/resources/db/migration/V1.0.11__update_notification_templates.sql
@@ -1,0 +1,53 @@
+-- ====================================
+-- 알림 템플릿 업데이트
+-- ====================================
+-- V1.0.10에서 추가된 템플릿을 삭제하고 새로운 템플릿으로 교체합니다.
+
+-- 기존에 V1.0.10에서 추가된 데이터 삭제
+DELETE FROM notification_template 
+WHERE template_type IN ('NEW_FOLLOW', 'SETTLEMENT_FAILED', 'CHAT_ROOM_INVITE');
+
+-- NEW_COMMENT_LIKE (COMMUNITY)
+INSERT INTO notification_template (notification_category_id, template_type, title, content, redirect_url)
+SELECT c.notification_category_id, 'NEW_COMMENT_LIKE', '새 댓글 좋아요',
+       '{userName}님이 댓글에 좋아요를 눌렀습니다.',
+       '/community/posts/{postId}'
+FROM notification_category c
+WHERE c.category_name = 'COMMUNITY'
+  AND NOT EXISTS (
+    SELECT 1 FROM notification_template t WHERE t.template_type = 'NEW_COMMENT_LIKE'
+  );
+
+-- SETTLEMENT_FAILED (SETTLEMENT)
+INSERT INTO notification_template (notification_category_id, template_type, title, content, redirect_url)
+SELECT c.notification_category_id, 'SETTLEMENT_FAILED', '정산 실패',
+       '{userName}님의 {settlementName} 정산이 실패했습니다. (정산 ID: {settlementId})',
+       '/settlements/{settlementId}'
+FROM notification_category c
+WHERE c.category_name = 'SETTLEMENT'
+  AND NOT EXISTS (
+    SELECT 1 FROM notification_template t WHERE t.template_type = 'SETTLEMENT_FAILED'
+  );
+
+-- NEW_REVIEW (PRODUCT)
+INSERT INTO notification_template (notification_category_id, template_type, title, content, redirect_url)
+SELECT c.notification_category_id, 'NEW_REVIEW', '새 리뷰 등록',
+       '{userName}님이 {productName} 상품에 리뷰를 등록했습니다.',
+       '/products/{productId}'
+FROM notification_category c
+WHERE c.category_name = 'PRODUCT'
+  AND NOT EXISTS (
+    SELECT 1 FROM notification_template t WHERE t.template_type = 'NEW_REVIEW'
+  );
+
+-- CUSTOM (판매자 등록 완료)
+INSERT INTO notification_template (notification_category_id, template_type, title, content, redirect_url)
+SELECT c.notification_category_id, 'SELLER_REGISTRATION_COMPLETE', '판매자 등록 완료',
+       '판매자 등록이 완료되었습니다.',
+       '/seller'
+FROM notification_category c
+WHERE c.category_name = 'SYSTEM'
+  AND NOT EXISTS (
+    SELECT 1 FROM notification_template t WHERE t.template_type = 'SELLER_REGISTRATION_COMPLETE' AND t.title = '판매자 등록 완료'
+  );
+


### PR DESCRIPTION
## 구현 내용
<!-- 구현한 기능에 대한 간략한 설명을 작성해주세요 -->

## ✨ 주요 변경 사항

### 1. 판매자 등급 자동 생성
- 판매자 역할 변경 시 등급을 랜덤하게 자동 할당 (1~5 등급)
- `UserService.updateUserRole()` 메서드에 등급 설정 로직 추가

### 2. 알림 시스템 개선
- 커스텀 알림 방식에서 템플릿 기반 알림 시스템으로 전환
- 타입 안전성을 위한 `SystemNotificationPayload.SellerRegistrationCompletePayload` 클래스 추가
- `NotificationEventType.SELLER_REGISTRATION_COMPLETE` 이벤트 타입 추가

### 3. 데이터베이스 마이그레이션
- 판매자 등록 완료 알림 템플릿 추가 (`V1.0.11__update_notification_templates.sql`)
- 기존 템플릿 정리 및 업데이트

### 주요 변경사항
<!-- 주요 변경사항을 작성해주세요 -->


## 테스트 완료 사항
<!-- 테스트한 항목에 체크(x)해주세요 -->
- [ ] 단위 테스트
- [ ] 통합 테스트
- [ ] API 테스트 (Swagger/Postman 등)
- [ x ] 기타 테스트


## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
closes #104 