### PR TITLE
test: User 및 인증 기능 리팩토링 및 테스트 작성

### DIFF
--- a/src/main/java/com/homesweet/homesweetback/common/exception/ErrorCode.java
+++ b/src/main/java/com/homesweet/homesweetback/common/exception/ErrorCode.java
@@ -13,6 +13,11 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
+
+    // Auth
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "Refresh Token을 찾을 수 없습니다"),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 Refresh Token입니다"),
+    INVALID_BIRTH_DATE(HttpStatus.BAD_REQUEST, "생일은 미래 날짜가 될 수 없습니다"),
     // System
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러입니다"),
     FILE_STREAM_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "파일 스트림 처리 중 오류가 발생했습니다"),

--- a/src/main/java/com/homesweet/homesweetback/common/exception/ErrorCode.java
+++ b/src/main/java/com/homesweet/homesweetback/common/exception/ErrorCode.java
@@ -14,10 +14,15 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode {
 
+    // User
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 사용자를 찾을 수 없습니다"),
+    GRADE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 등급을 찾을 수 없습니다"),
+
     // Auth
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "Refresh Token을 찾을 수 없습니다"),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 Refresh Token입니다"),
     INVALID_BIRTH_DATE(HttpStatus.BAD_REQUEST, "생일은 미래 날짜가 될 수 없습니다"),
+    INVALID_PHONE_NUMBER_FORMAT(HttpStatus.BAD_REQUEST, "올바른 핸드폰 번호 형식이 아닙니다"),
     // System
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러입니다"),
     FILE_STREAM_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "파일 스트림 처리 중 오류가 발생했습니다"),
@@ -50,7 +55,6 @@ public enum ErrorCode {
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "유효하지 않은 입력값입니다."),
 
     // Community
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 사용자를 찾을 수 없습니다"),
     COMMUNITY_POST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 게시글을 찾을 수 없습니다"),
     COMMUNITY_POST_FORBIDDEN(HttpStatus.FORBIDDEN, "본인이 작성한 게시글만 수정/삭제할 수 있습니다"),
     COMMUNITY_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 댓글을 찾을 수 없습니다"),

--- a/src/main/java/com/homesweet/homesweetback/domain/auth/repository/InMemoryRefreshTokenRepository.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/auth/repository/InMemoryRefreshTokenRepository.java
@@ -25,4 +25,9 @@ public class InMemoryRefreshTokenRepository implements RefreshTokenRepository {
     public void deleteByEmail(String email) {
         refreshTokenMap.remove(email);
     }
+
+    @Override
+    public void deleteByRefreshToken(String refreshToken) {
+        refreshTokenMap.values().remove(refreshToken);
+    }
 }

--- a/src/main/java/com/homesweet/homesweetback/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/auth/repository/RefreshTokenRepository.java
@@ -6,4 +6,5 @@ public interface RefreshTokenRepository {
     boolean save(String email, String refreshToken);
     String findByEmail(String email);
     void deleteByEmail(String email);
+    void deleteByRefreshToken(String refreshToken);
 }

--- a/src/main/java/com/homesweet/homesweetback/domain/auth/repository/UserRepository.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/auth/repository/UserRepository.java
@@ -11,26 +11,10 @@ import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-    
-    Optional<User> findByEmail(String email);
-    
-    boolean existsByEmail(String email);
-    
     /**
      * OAuth Provider와 Provider ID로 사용자 조회
      */
     Optional<User> findByProviderAndProviderId(OAuth2Provider provider, String providerId);
-    
-    /**
-     * OAuth Provider와 Provider ID로 사용자 존재 여부 확인
-     */
-    boolean existsByProviderAndProviderId(OAuth2Provider provider, String providerId);
-    
-    /**
-     * 이메일과 Provider로 사용자 조회
-     */
-    Optional<User> findByEmailAndProvider(String email, OAuth2Provider provider);
-
 
 
     List<User> findAllByRole(UserRole role);

--- a/src/main/java/com/homesweet/homesweetback/domain/auth/service/AuthService.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/auth/service/AuthService.java
@@ -138,12 +138,17 @@ public class AuthService {
         // Authorization 헤더에서 Access Token 추출
         String accessToken = getAccessTokenFromRequest(request);
 
-        if (jwtTokenProvider.validateToken(accessToken)) {
+        if (accessToken != null && jwtTokenProvider.validateToken(accessToken)) {
             Long userId = jwtTokenProvider.getUserIdFromToken(accessToken);
             String email = jwtTokenProvider.getEmailFromToken(accessToken);
                 
             log.info("User logout successful: userId={}, email={}", userId, email);
             refreshTokenRepository.deleteByEmail(email);
+        } else {
+            String refreshToken = getRefreshTokenFromRequest(request);
+            if (refreshToken != null && jwtTokenProvider.validateToken(refreshToken)) {
+                refreshTokenRepository.deleteByRefreshToken(refreshToken);
+            }
         }
         
         // Refresh Token Cookie 삭제
@@ -202,11 +207,7 @@ public class AuthService {
      * Refresh Token으로 사용자 정보를 조회합니다.
      */
     private User getUserFromRefreshToken(HttpServletRequest request) {
-        String refreshToken = cookieUtil.getRefreshTokenFromCookie(request);
-        
-        if (refreshToken == null) {
-            throw new BusinessException(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
-        }
+        String refreshToken = getRefreshTokenFromRequest(request);
         
         if (!jwtTokenProvider.validateToken(refreshToken) || !jwtTokenProvider.isRefreshToken(refreshToken)) {
             throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);

--- a/src/main/java/com/homesweet/homesweetback/domain/auth/service/AuthService.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/auth/service/AuthService.java
@@ -1,5 +1,7 @@
 package com.homesweet.homesweetback.domain.auth.service;
 
+import com.homesweet.homesweetback.common.exception.BusinessException;
+import com.homesweet.homesweetback.common.exception.ErrorCode;
 import com.homesweet.homesweetback.common.security.jwt.JwtTokenProvider;
 import com.homesweet.homesweetback.common.util.CookieUtil;
 import com.homesweet.homesweetback.domain.auth.dto.*;
@@ -35,30 +37,16 @@ public class AuthService {
     @Transactional
     public AccessTokenResponse refreshToken(HttpServletRequest request, HttpServletResponse response) {
         // Cookie에서 Refresh Token 추출
-        String refreshToken = cookieUtil.getRefreshTokenFromCookie(request);
-
-        if (refreshToken == null) {
-            throw new IllegalArgumentException("Refresh token not found");
-        }
+        String refreshToken = getRefreshTokenFromRequest(request);
 
         // Refresh Token 유효성 검증
-        if (!jwtTokenProvider.validateToken(refreshToken) || !jwtTokenProvider.isRefreshToken(refreshToken)) {
-            // 유효하지 않은 refresh token인 경우 cookie 삭제
-            Cookie deleteCookie = cookieUtil.createRefreshTokenCookieForDeletion();
-            response.addCookie(deleteCookie);
-            throw new IllegalArgumentException("Invalid refresh token");
-        }
+        validateRefreshToken(response, refreshToken);
 
-        // ✅ 수정: userId로 먼저 사용자 조회
-        Long userId = jwtTokenProvider.getUserIdFromToken(refreshToken);
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new RuntimeException("User not found"));
+        // Refresh Token으로 사용자 조회
+        User user = getUserById(jwtTokenProvider.getUserIdFromToken(refreshToken));
 
-        // ✅ 수정: 조회한 사용자의 email로 저장된 토큰 확인
-        String storedRefreshToken = refreshTokenRepository.findByEmail(user.getEmail());
-        if (storedRefreshToken == null || !storedRefreshToken.equals(refreshToken)) {
-            throw new IllegalArgumentException("Invalid refresh token");
-        }
+        // 조회한 사용자의 email로 저장된 토큰 확인
+        validateStoredRefreshToken(refreshToken, user);
 
         // 새로운 Access Token과 Refresh Token 생성
         String newAccessToken = jwtTokenProvider.createAccessToken(user);
@@ -72,24 +60,6 @@ public class AuthService {
         log.info("Token refreshed successfully for user: {}", user.getEmail());
 
         return new AccessTokenResponse(newAccessToken,UserResponse.of(user));
-    }
-    /**
-     * Refresh Token으로 사용자 정보를 조회합니다.
-     */
-    public User getUserFromRefreshToken(HttpServletRequest request) {
-        String refreshToken = cookieUtil.getRefreshTokenFromCookie(request);
-        
-        if (refreshToken == null) {
-            throw new IllegalArgumentException("Refresh token not found");
-        }
-        
-        if (!jwtTokenProvider.validateToken(refreshToken) || !jwtTokenProvider.isRefreshToken(refreshToken)) {
-            throw new IllegalArgumentException("Invalid refresh token");
-        }
-        
-        Long userId = jwtTokenProvider.getUserIdFromToken(refreshToken);
-        return userRepository.findById(userId)
-            .orElseThrow(() -> new RuntimeException("User not found"));
     }
 
 
@@ -133,14 +103,9 @@ public class AuthService {
         // Refresh Token으로 사용자 조회
         User user = getUserFromRefreshToken(request);
         
-        // 핸드폰 번호 검증
-        if (!PhoneNumberValidator.isValid(signupRequest.phoneNumber())) {
-            throw new IllegalArgumentException("올바른 핸드폰 번호 형식이 아닙니다");
-        }
-        
         // 생일 검증 (미래 날짜 불가)
         if (signupRequest.birthDate().isAfter(java.time.LocalDate.now())) {
-            throw new IllegalArgumentException("생일은 미래 날짜가 될 수 없습니다");
+            throw new BusinessException(ErrorCode.INVALID_BIRTH_DATE);
         }
         
         // 사용자 정보 업데이트
@@ -171,21 +136,94 @@ public class AuthService {
      */
     public void logout(HttpServletRequest request, HttpServletResponse response) {
         // Authorization 헤더에서 Access Token 추출
-        String authHeader = request.getHeader("Authorization");
-        if (authHeader != null && authHeader.startsWith("Bearer ")) {
-            String accessToken = authHeader.substring(7);
-            
-            if (jwtTokenProvider.validateToken(accessToken)) {
-                Long userId = jwtTokenProvider.getUserIdFromToken(accessToken);
-                String email = jwtTokenProvider.getEmailFromToken(accessToken);
+        String accessToken = getAccessTokenFromRequest(request);
+
+        if (jwtTokenProvider.validateToken(accessToken)) {
+            Long userId = jwtTokenProvider.getUserIdFromToken(accessToken);
+            String email = jwtTokenProvider.getEmailFromToken(accessToken);
                 
-                log.info("User logout successful: userId={}, email={}", userId, email);
-                refreshTokenRepository.deleteByEmail(email);
-            }
+            log.info("User logout successful: userId={}, email={}", userId, email);
+            refreshTokenRepository.deleteByEmail(email);
         }
         
         // Refresh Token Cookie 삭제
         Cookie deleteCookie = cookieUtil.createRefreshTokenCookieForDeletion();
         response.addCookie(deleteCookie);
     }
+
+    // 내부 메서드
+
+    /**
+     * Authorization 헤더에서 Access Token을 추출합니다.
+     */
+    private String getAccessTokenFromRequest(HttpServletRequest request) {
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            return authHeader.substring(7);
+        }
+        return null;
+    }
+
+    /**
+     * Cookie에서 Refresh Token을 추출합니다.
+     */
+    private String getRefreshTokenFromRequest(HttpServletRequest request) {
+        String refreshToken = cookieUtil.getRefreshTokenFromCookie(request);
+
+        if (refreshToken == null) {
+            throw new BusinessException(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
+        }
+        return refreshToken;
+    }
+
+
+    /**
+     * Refresh Token 유효성 검증
+     */
+    private void validateRefreshToken(HttpServletResponse response, String refreshToken) {
+        if (!jwtTokenProvider.validateToken(refreshToken) || !jwtTokenProvider.isRefreshToken(refreshToken)) {
+            // 유효하지 않은 refresh token인 경우 cookie 삭제
+            Cookie deleteCookie = cookieUtil.createRefreshTokenCookieForDeletion();
+            response.addCookie(deleteCookie);
+            throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+    }
+
+    /**
+     * User ID로 사용자 정보를 조회합니다.
+     */
+    private User getUserById(Long userId) {
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    }
+
+
+    /**
+     * Refresh Token으로 사용자 정보를 조회합니다.
+     */
+    private User getUserFromRefreshToken(HttpServletRequest request) {
+        String refreshToken = cookieUtil.getRefreshTokenFromCookie(request);
+        
+        if (refreshToken == null) {
+            throw new BusinessException(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
+        }
+        
+        if (!jwtTokenProvider.validateToken(refreshToken) || !jwtTokenProvider.isRefreshToken(refreshToken)) {
+            throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+        
+        Long userId = jwtTokenProvider.getUserIdFromToken(refreshToken);
+        return getUserById(userId);
+    }
+
+    /**
+     * 저장된 Refresh Token과 비교하여 유효성 검증
+     */
+    private void validateStoredRefreshToken(String refreshToken, User user) {
+        String storedRefreshToken = refreshTokenRepository.findByEmail(user.getEmail());
+        if (storedRefreshToken == null || !storedRefreshToken.equals(refreshToken)) {
+            throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
+        }
+    }
+
 }

--- a/src/main/java/com/homesweet/homesweetback/domain/auth/service/UserService.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/auth/service/UserService.java
@@ -43,6 +43,12 @@ public class UserService {
         return UserResponse.of(user);
     }
 
+    @Transactional(readOnly = true)
+    public User getUserById(Long userId) {
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new RuntimeException("User not found with id: " + userId));
+    }
+
     /**
      * 사용자 정보 수정
      */

--- a/src/main/java/com/homesweet/homesweetback/domain/auth/service/UserService.java
+++ b/src/main/java/com/homesweet/homesweetback/domain/auth/service/UserService.java
@@ -8,6 +8,8 @@ import com.homesweet.homesweetback.domain.grade.entity.Grade;
 import com.homesweet.homesweetback.domain.grade.repository.GradeRepository;
 import com.homesweet.homesweetback.domain.auth.repository.UserRepository;
 import com.homesweet.homesweetback.common.util.PhoneNumberValidator;
+import com.homesweet.homesweetback.common.exception.BusinessException;
+import com.homesweet.homesweetback.common.exception.ErrorCode;
 import com.homesweet.homesweetback.common.s3.ImageUploader;
 
 import java.math.BigDecimal;
@@ -37,7 +39,7 @@ public class UserService {
     @Transactional(readOnly = true)
     public UserResponse getUserInfo(Long userId) {
         User user = userRepository.findById(userId)
-            .orElseThrow(() -> new RuntimeException("User not found with id: " + userId));
+            .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         
         log.debug("User info retrieved: {}", user.getEmail());
         return UserResponse.of(user);
@@ -46,7 +48,7 @@ public class UserService {
     @Transactional(readOnly = true)
     public User getUserById(Long userId) {
         return userRepository.findById(userId)
-            .orElseThrow(() -> new RuntimeException("User not found with id: " + userId));
+            .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
     }
 
     /**
@@ -55,21 +57,21 @@ public class UserService {
     @Transactional
     public UserResponse updateUserInfo(Long userId, UpdateUserRequest request, Optional<MultipartFile> profileImage) {
         User user = userRepository.findById(userId)
-            .orElseThrow(() -> new RuntimeException("User not found with id: " + userId));
+            .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         
         if (profileImage.isPresent()) {
             try{
                 imageUploader.delete(user.getProfileImageUrl());
             } catch (Exception e) {
                 log.error("프로필 이미지 삭제 실패: userId={}", userId, e);
-                throw new RuntimeException("프로필 이미지 삭제에 실패했습니다: " + e.getMessage());
+                throw new BusinessException(ErrorCode.FILE_STREAM_ERROR);
             }
             try{
                 String uploadedUrl = imageUploader.upload(profileImage.get(), "user/profile/" + userId);
                 user.setProfileImageUrl(uploadedUrl);
             } catch (Exception e) {
                 log.error("프로필 이미지 업로드 실패: userId={}", userId, e);
-                throw new RuntimeException("프로필 이미지 업로드에 실패했습니다: " + e.getMessage());
+                throw new BusinessException(ErrorCode.FILE_STREAM_ERROR);
             }
         }
         
@@ -81,7 +83,7 @@ public class UserService {
         if (request.phoneNumber() != null) {
             // 핸드폰 번호 검증
             if (!PhoneNumberValidator.isValid(request.phoneNumber())) {
-                throw new IllegalArgumentException("올바른 핸드폰 번호 형식이 아닙니다");
+                throw new BusinessException(ErrorCode.INVALID_PHONE_NUMBER_FORMAT);
             }
             user.setPhoneNumber(PhoneNumberValidator.format(request.phoneNumber()));
         }
@@ -106,7 +108,7 @@ public class UserService {
     @Transactional
     public void deleteUser(Long userId) {
         User user = userRepository.findById(userId) 
-            .orElseThrow(() -> new RuntimeException("User not found with id: " + userId));
+            .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         
         userRepository.delete(user);
         log.info("User account deleted: {}", user.getEmail());
@@ -118,13 +120,13 @@ public class UserService {
     @Transactional
     public UserResponse updateUserRole(Long userId, UpdateUserRoleRequest request) {
         User user = userRepository.findById(userId)
-            .orElseThrow(() -> new RuntimeException("User not found with id: " + userId));
+            .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         user.setRole(request.role());
         
         // 판매자 등급 랜덤 설정
         Integer gradeId = ThreadLocalRandom.current().nextInt(1, 6);
         Grade grade = gradeRepository.findById(gradeId)
-            .orElseThrow(() -> new RuntimeException("Grade not found with id: " + gradeId));
+            .orElseThrow(() -> new BusinessException(ErrorCode.GRADE_NOT_FOUND));
         user.setGrade(grade);
         
         return UserResponse.of(userRepository.save(user));
@@ -137,7 +139,7 @@ public class UserService {
     @Transactional(readOnly = true)
     public Optional<Grade> getUserGrade(Long userId) {
         User user = userRepository.findById(userId)
-            .orElseThrow(() -> new RuntimeException("User not found with id: " + userId));
+            .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         
         return user.getGradeOptional();
     }
@@ -149,7 +151,7 @@ public class UserService {
     @Transactional(readOnly = true)
     public String getUserGradeName(Long userId) {
         User user = userRepository.findById(userId)
-            .orElseThrow(() -> new RuntimeException("User not found with id: " + userId));
+            .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         
         return user.getGradeName();
     }
@@ -161,7 +163,7 @@ public class UserService {
     @Transactional(readOnly = true)
     public BigDecimal getUserFeeRate(Long userId) {
         User user = userRepository.findById(userId)
-            .orElseThrow(() -> new RuntimeException("User not found with id: " + userId));
+            .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         
         return user.getFeeRate();
     }
@@ -172,7 +174,7 @@ public class UserService {
     @Transactional(readOnly = true)
     public boolean hasUserGrade(Long userId) {
         User user = userRepository.findById(userId)
-            .orElseThrow(() -> new RuntimeException("User not found with id: " + userId));
+            .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         
         return user.hasGrade();
     }

--- a/src/test/java/com/homesweet/homesweetback/domain/auth/entity/OAuth2ProviderTest.java
+++ b/src/test/java/com/homesweet/homesweetback/domain/auth/entity/OAuth2ProviderTest.java
@@ -1,0 +1,81 @@
+package com.homesweet.homesweetback.domain.auth.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("OAuth2Provider 테스트")
+class OAuth2ProviderTest {
+
+    @Test
+    @DisplayName("getProviderName() 메서드 테스트_성공_GOOGLE")
+    void testGetProviderName_Success_Google() {
+        // when
+        String providerName = OAuth2Provider.GOOGLE.getProviderName();
+
+        // then
+        assertThat(providerName).isEqualTo("google");
+    }
+
+    @Test
+    @DisplayName("getProviderName() 메서드 테스트_성공_KAKAO")
+    void testGetProviderName_Success_Kakao() {
+        // when
+        String providerName = OAuth2Provider.KAKAO.getProviderName();
+
+        // then
+        assertThat(providerName).isEqualTo("kakao");
+    }
+
+    @Test
+    @DisplayName("fromProviderName() 메서드 테스트_성공_GOOGLE")
+    void testFromProviderName_Success_Google() {
+        // when
+        OAuth2Provider provider = OAuth2Provider.fromProviderName("google");
+
+        // then
+        assertThat(provider).isEqualTo(OAuth2Provider.GOOGLE);
+        assertThat(provider.getProviderName()).isEqualTo("google");
+    }
+
+    @Test
+    @DisplayName("fromProviderName() 메서드 테스트_성공_KAKAO")
+    void testFromProviderName_Success_Kakao() {
+        // when
+        OAuth2Provider provider = OAuth2Provider.fromProviderName("kakao");
+
+        // then
+        assertThat(provider).isEqualTo(OAuth2Provider.KAKAO);
+        assertThat(provider.getProviderName()).isEqualTo("kakao");
+    }
+
+    @Test
+    @DisplayName("fromProviderName() 메서드 테스트_실패_지원하지 않는 Provider")
+    void testFromProviderName_Fail_UnsupportedProvider() {
+        // when & then
+        assertThatThrownBy(() -> OAuth2Provider.fromProviderName("facebook"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unsupported OAuth2 provider: facebook");
+    }
+
+    @Test
+    @DisplayName("fromProviderName() 메서드 테스트_실패_null 값")
+    void testFromProviderName_Fail_Null() {
+        // when & then
+        assertThatThrownBy(() -> OAuth2Provider.fromProviderName(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unsupported OAuth2 provider: null");
+    }
+
+    @Test
+    @DisplayName("fromProviderName() 메서드 테스트_실패_빈 문자열")
+    void testFromProviderName_Fail_EmptyString() {
+        // when & then
+        assertThatThrownBy(() -> OAuth2Provider.fromProviderName(""))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unsupported OAuth2 provider: ");
+    }
+}
+

--- a/src/test/java/com/homesweet/homesweetback/domain/auth/entity/OAuth2UserPrincipalTest.java
+++ b/src/test/java/com/homesweet/homesweetback/domain/auth/entity/OAuth2UserPrincipalTest.java
@@ -1,0 +1,155 @@
+package com.homesweet.homesweetback.domain.auth.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.GrantedAuthority;
+
+@DisplayName("OAuth2UserPrincipal 테스트")
+class OAuth2UserPrincipalTest {
+
+    @Test
+    @DisplayName("getAttributes() 메서드 테스트_성공")
+    void testGetAttributes_Success() {
+        // given
+        User user = createTestUser();
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("sub", "123456789");
+        attributes.put("email", "test@test.com");
+        attributes.put("name", "Test User");
+        OAuth2UserPrincipal principal = new OAuth2UserPrincipal(user, attributes);
+
+        // when
+        Map<String, Object> result = principal.getAttributes();
+
+        // then
+        assertThat(result).isEqualTo(attributes);
+        assertThat(result.get("sub")).isEqualTo("123456789");
+        assertThat(result.get("email")).isEqualTo("test@test.com");
+    }
+
+    @Test
+    @DisplayName("getAuthorities() 메서드 테스트_성공_ROLE_USER 반환")
+    void testGetAuthorities_Success() {
+        // given
+        User user = createTestUser();
+        Map<String, Object> attributes = new HashMap<>();
+        OAuth2UserPrincipal principal = new OAuth2UserPrincipal(user, attributes);
+
+        // when
+        var authorities = principal.getAuthorities();
+
+        // then
+        assertThat(authorities).isNotEmpty();
+        assertThat(authorities.size()).isEqualTo(1);
+        GrantedAuthority authority = authorities.iterator().next();
+        assertThat(authority.getAuthority()).isEqualTo("ROLE_USER");
+    }
+
+    @Test
+    @DisplayName("getName() 메서드 테스트_성공_이메일 반환")
+    void testGetName_Success() {
+        // given
+        User user = createTestUser();
+        Map<String, Object> attributes = new HashMap<>();
+        OAuth2UserPrincipal principal = new OAuth2UserPrincipal(user, attributes);
+
+        // when
+        String name = principal.getName();
+
+        // then
+        assertThat(name).isEqualTo("test@test.com");
+    }
+
+    @Test
+    @DisplayName("getUserId() 메서드 테스트_성공")
+    void testGetUserId_Success() {
+        // given
+        User user = createTestUser();
+        user.setId(1L);
+        Map<String, Object> attributes = new HashMap<>();
+        OAuth2UserPrincipal principal = new OAuth2UserPrincipal(user, attributes);
+
+        // when
+        Long userId = principal.getUserId();
+
+        // then
+        assertThat(userId).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("getEmail() 메서드 테스트_성공")
+    void testGetEmail_Success() {
+        // given
+        User user = createTestUser();
+        Map<String, Object> attributes = new HashMap<>();
+        OAuth2UserPrincipal principal = new OAuth2UserPrincipal(user, attributes);
+
+        // when
+        String email = principal.getEmail();
+
+        // then
+        assertThat(email).isEqualTo("test@test.com");
+    }
+
+    @Test
+    @DisplayName("getDisplayName() 메서드 테스트_성공")
+    void testGetDisplayName_Success() {
+        // given
+        User user = createTestUser();
+        Map<String, Object> attributes = new HashMap<>();
+        OAuth2UserPrincipal principal = new OAuth2UserPrincipal(user, attributes);
+
+        // when
+        String displayName = principal.getDisplayName();
+
+        // then
+        assertThat(displayName).isEqualTo("test");
+    }
+
+    @Test
+    @DisplayName("getProvider() 메서드 테스트_성공")
+    void testGetProvider_Success() {
+        // given
+        User user = createTestUser();
+        Map<String, Object> attributes = new HashMap<>();
+        OAuth2UserPrincipal principal = new OAuth2UserPrincipal(user, attributes);
+
+        // when
+        String provider = principal.getProvider();
+
+        // then
+        assertThat(provider).isEqualTo("google");
+    }
+
+    @Test
+    @DisplayName("생성자 테스트_User와 Attributes 저장 확인")
+    void testConstructor_Success() {
+        // given
+        User user = createTestUser();
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("sub", "123456789");
+
+        // when
+        OAuth2UserPrincipal principal = new OAuth2UserPrincipal(user, attributes);
+
+        // then
+        assertThat(principal.getUser()).isEqualTo(user);
+        assertThat(principal.getAttributes()).isEqualTo(attributes);
+    }
+
+    private User createTestUser() {
+        return User.builder()
+                .email("test@test.com")
+                .name("test")
+                .role(UserRole.USER)
+                .provider(OAuth2Provider.GOOGLE)
+                .providerId("123456789")
+                .build();
+    }
+}
+

--- a/src/test/java/com/homesweet/homesweetback/domain/auth/entity/UserRoleTest.java
+++ b/src/test/java/com/homesweet/homesweetback/domain/auth/entity/UserRoleTest.java
@@ -1,0 +1,83 @@
+package com.homesweet.homesweetback.domain.auth.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("UserRole 테스트")
+class UserRoleTest {
+
+    @Test
+    @DisplayName("getAuthority() 메서드 테스트_USER")
+    void testGetAuthority_User() {
+        // when
+        String authority = UserRole.USER.getAuthority();
+
+        // then
+        assertThat(authority).isEqualTo("ROLE_USER");
+    }
+
+    @Test
+    @DisplayName("getAuthority() 메서드 테스트_SELLER")
+    void testGetAuthority_Seller() {
+        // when
+        String authority = UserRole.SELLER.getAuthority();
+
+        // then
+        assertThat(authority).isEqualTo("ROLE_SELLER");
+    }
+
+    @Test
+    @DisplayName("fromAuthority() 메서드 테스트_성공_USER")
+    void testFromAuthority_Success_User() {
+        // when
+        UserRole role = UserRole.fromAuthority("ROLE_USER");
+
+        // then
+        assertThat(role).isEqualTo(UserRole.USER);
+        assertThat(role.getAuthority()).isEqualTo("ROLE_USER");
+    }
+
+    @Test
+    @DisplayName("fromAuthority() 메서드 테스트_성공_SELLER")
+    void testFromAuthority_Success_Seller() {
+        // when
+        UserRole role = UserRole.fromAuthority("ROLE_SELLER");
+
+        // then
+        assertThat(role).isEqualTo(UserRole.SELLER);
+        assertThat(role.getAuthority()).isEqualTo("ROLE_SELLER");
+    }
+
+    @Test
+    @DisplayName("fromAuthority() 메서드 테스트_실패_지원하지 않는 Authority")
+    void testFromAuthority_Fail_UnsupportedAuthority() {
+        // when
+        UserRole role = UserRole.fromAuthority("ROLE_ADMIN");
+
+        // then
+        assertThat(role).isNull();
+    }
+
+    @Test
+    @DisplayName("fromAuthority() 메서드 테스트_실패_null 값")
+    void testFromAuthority_Fail_Null() {
+        // when
+        UserRole role = UserRole.fromAuthority(null);
+
+        // then
+        assertThat(role).isNull();
+    }
+
+    @Test
+    @DisplayName("fromAuthority() 메서드 테스트_실패_빈 문자열")
+    void testFromAuthority_Fail_EmptyString() {
+        // when
+        UserRole role = UserRole.fromAuthority("");
+
+        // then
+        assertThat(role).isNull();
+    }
+}
+

--- a/src/test/java/com/homesweet/homesweetback/domain/auth/entity/UserTest.java
+++ b/src/test/java/com/homesweet/homesweetback/domain/auth/entity/UserTest.java
@@ -52,13 +52,11 @@ class UserTest {
                 .providerId("123456789")
                 .build();
 
-        // when
-        // 현재 GOOGLE만 지원하므로 다른 Provider는 테스트할 수 없지만,
-        // 메서드 로직은 정상적으로 동작함을 확인
-        boolean isSameProvider = user.isSameProvider(OAuth2Provider.GOOGLE);
+        // whe
+        boolean isSameProvider = user.isSameProvider(OAuth2Provider.KAKAO);
 
         // then
-        assertThat(isSameProvider).isTrue();
+        assertThat(isSameProvider).isFalse();
     }
 
     @Test

--- a/src/test/java/com/homesweet/homesweetback/domain/auth/entity/UserTest.java
+++ b/src/test/java/com/homesweet/homesweetback/domain/auth/entity/UserTest.java
@@ -1,0 +1,225 @@
+package com.homesweet.homesweetback.domain.auth.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.homesweet.homesweetback.domain.grade.entity.Grade;
+
+@DisplayName("User 엔티티 테스트")
+class UserTest {
+
+    @Test
+    @DisplayName("isOAuthUser() 메서드 테스트_항상 true 반환")
+    void testIsOAuthUser_AlwaysTrue() {
+        // given
+        User user = createTestUser();
+
+        // when
+        boolean isOAuthUser = user.isOAuthUser();
+
+        // then
+        assertThat(isOAuthUser).isTrue();
+    }
+
+    @Test
+    @DisplayName("isSameProvider() 메서드 테스트_성공_같은 Provider")
+    void testIsSameProvider_Success_SameProvider() {
+        // given
+        User user = createTestUser();
+        OAuth2Provider provider = OAuth2Provider.GOOGLE;
+
+        // when
+        boolean isSameProvider = user.isSameProvider(provider);
+
+        // then
+        assertThat(isSameProvider).isTrue();
+    }
+
+    @Test
+    @DisplayName("isSameProvider() 메서드 테스트_실패_다른 Provider")
+    void testIsSameProvider_Fail_DifferentProvider() {
+        // given
+        User user = User.builder()
+                .email("test@test.com")
+                .name("test")
+                .role(UserRole.USER)
+                .provider(OAuth2Provider.GOOGLE)
+                .providerId("123456789")
+                .build();
+
+        // when
+        // 현재 GOOGLE만 지원하므로 다른 Provider는 테스트할 수 없지만,
+        // 메서드 로직은 정상적으로 동작함을 확인
+        boolean isSameProvider = user.isSameProvider(OAuth2Provider.GOOGLE);
+
+        // then
+        assertThat(isSameProvider).isTrue();
+    }
+
+    @Test
+    @DisplayName("getGradeOptional() 메서드 테스트_성공_등급이 있는 경우")
+    void testGetGradeOptional_Success_WithGrade() {
+        // given
+        Grade grade = Grade.builder()
+                .grade("GOLD")
+                .feeRate(new BigDecimal("5.00"))
+                .build();
+        User user = User.builder()
+                .email("test@test.com")
+                .name("test")
+                .role(UserRole.USER)
+                .provider(OAuth2Provider.GOOGLE)
+                .providerId("123456789")
+                .grade(grade)
+                .build();
+
+        // when
+        Optional<Grade> gradeOptional = user.getGradeOptional();
+
+        // then
+        assertThat(gradeOptional).isPresent();
+        assertThat(gradeOptional.get()).isEqualTo(grade);
+        assertThat(gradeOptional.get().getGrade()).isEqualTo("GOLD");
+    }
+
+    @Test
+    @DisplayName("getGradeOptional() 메서드 테스트_성공_등급이 없는 경우")
+    void testGetGradeOptional_Success_WithoutGrade() {
+        // given
+        User user = createTestUser();
+
+        // when
+        Optional<Grade> gradeOptional = user.getGradeOptional();
+
+        // then
+        assertThat(gradeOptional).isEmpty();
+    }
+
+    @Test
+    @DisplayName("hasGrade() 메서드 테스트_성공_등급이 있는 경우")
+    void testHasGrade_Success_WithGrade() {
+        // given
+        Grade grade = Grade.builder()
+                .grade("GOLD")
+                .feeRate(new BigDecimal("5.00"))
+                .build();
+        User user = User.builder()
+                .email("test@test.com")
+                .name("test")
+                .role(UserRole.USER)
+                .provider(OAuth2Provider.GOOGLE)
+                .providerId("123456789")
+                .grade(grade)
+                .build();
+
+        // when
+        boolean hasGrade = user.hasGrade();
+
+        // then
+        assertThat(hasGrade).isTrue();
+    }
+
+    @Test
+    @DisplayName("hasGrade() 메서드 테스트_성공_등급이 없는 경우")
+    void testHasGrade_Success_WithoutGrade() {
+        // given
+        User user = createTestUser();
+
+        // when
+        boolean hasGrade = user.hasGrade();
+
+        // then
+        assertThat(hasGrade).isFalse();
+    }
+
+    @Test
+    @DisplayName("getGradeName() 메서드 테스트_성공_등급이 있는 경우")
+    void testGetGradeName_Success_WithGrade() {
+        // given
+        Grade grade = Grade.builder()
+                .grade("GOLD")
+                .feeRate(new BigDecimal("5.00"))
+                .build();
+        User user = User.builder()
+                .email("test@test.com")
+                .name("test")
+                .role(UserRole.USER)
+                .provider(OAuth2Provider.GOOGLE)
+                .providerId("123456789")
+                .grade(grade)
+                .build();
+
+        // when
+        String gradeName = user.getGradeName();
+
+        // then
+        assertThat(gradeName).isEqualTo("GOLD");
+    }
+
+    @Test
+    @DisplayName("getGradeName() 메서드 테스트_성공_등급이 없는 경우")
+    void testGetGradeName_Success_WithoutGrade() {
+        // given
+        User user = createTestUser();
+
+        // when
+        String gradeName = user.getGradeName();
+
+        // then
+        assertThat(gradeName).isEqualTo("등급 없음");
+    }
+
+    @Test
+    @DisplayName("getFeeRate() 메서드 테스트_성공_등급이 있는 경우")
+    void testGetFeeRate_Success_WithGrade() {
+        // given
+        BigDecimal feeRate = new BigDecimal("5.00");
+        Grade grade = Grade.builder()
+                .grade("GOLD")
+                .feeRate(feeRate)
+                .build();
+        User user = User.builder()
+                .email("test@test.com")
+                .name("test")
+                .role(UserRole.USER)
+                .provider(OAuth2Provider.GOOGLE)
+                .providerId("123456789")
+                .grade(grade)
+                .build();
+
+        // when
+        BigDecimal userFeeRate = user.getFeeRate();
+
+        // then
+        assertThat(userFeeRate).isEqualByComparingTo(feeRate);
+    }
+
+    @Test
+    @DisplayName("getFeeRate() 메서드 테스트_성공_등급이 없는 경우")
+    void testGetFeeRate_Success_WithoutGrade() {
+        // given
+        User user = createTestUser();
+
+        // when
+        BigDecimal feeRate = user.getFeeRate();
+
+        // then
+        assertThat(feeRate).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    private User createTestUser() {
+        return User.builder()
+                .email("test@test.com")
+                .name("test")
+                .role(UserRole.USER)
+                .provider(OAuth2Provider.GOOGLE)
+                .providerId("123456789")
+                .build();
+    }
+}
+

--- a/src/test/java/com/homesweet/homesweetback/domain/auth/repository/RefreshTokenRepositoryTest.java
+++ b/src/test/java/com/homesweet/homesweetback/domain/auth/repository/RefreshTokenRepositoryTest.java
@@ -1,0 +1,162 @@
+package com.homesweet.homesweetback.domain.auth.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.homesweet.homesweetback.common.config.QueryDslConfig;
+import com.homesweet.homesweetback.domain.product.category.repository.impl.ProductCategoryRepositoryImpl;
+import com.homesweet.homesweetback.domain.product.category.repository.mapper.ProductCategoryMapper;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@DisplayName("RefreshTokenRepository 테스트")
+@Import({
+    QueryDslConfig.class,
+    ProductCategoryRepositoryImpl.class,
+    ProductCategoryMapper.class,
+    InMemoryRefreshTokenRepository.class
+})
+class RefreshTokenRepositoryTest {
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+    
+    private static final String TEST_EMAIL = "test@test.com";
+    private static final String TEST_REFRESH_TOKEN = "test-refresh-token-12345";
+    private static final String ANOTHER_EMAIL = "another@test.com";
+    private static final String ANOTHER_REFRESH_TOKEN = "another-refresh-token-67890";
+    
+    @BeforeEach
+    void setUp() {
+        // 각 테스트 전에 저장소 초기화를 위해 모든 데이터 삭제
+        refreshTokenRepository.deleteByEmail(TEST_EMAIL);
+        refreshTokenRepository.deleteByEmail(ANOTHER_EMAIL);
+    }
+    
+    @Test
+    @DisplayName("RefreshToken 저장 테스트_성공")
+    void testSave_Success() {
+        // given
+        String email = TEST_EMAIL;
+        String refreshToken = TEST_REFRESH_TOKEN;
+
+        // when
+        boolean result = refreshTokenRepository.save(email, refreshToken);
+
+        // then
+        assertThat(result).isTrue();
+        String savedToken = refreshTokenRepository.findByEmail(email);
+        assertThat(savedToken).isEqualTo(refreshToken);
+    }
+    
+    @Test
+    @DisplayName("RefreshToken 저장 후 조회 테스트_성공")
+    void testFindByEmail_Success() {
+        // given
+        refreshTokenRepository.save(TEST_EMAIL, TEST_REFRESH_TOKEN);
+
+        // when
+        String foundToken = refreshTokenRepository.findByEmail(TEST_EMAIL);
+
+        // then
+        assertThat(foundToken).isNotNull();
+        assertThat(foundToken).isEqualTo(TEST_REFRESH_TOKEN);
+    }
+    
+    @Test
+    @DisplayName("존재하지 않는 이메일로 RefreshToken 조회 테스트_실패")
+    void testFindByEmail_NotFound() {
+        // given
+        String nonExistentEmail = "nonexistent@test.com";
+
+        // when
+        String foundToken = refreshTokenRepository.findByEmail(nonExistentEmail);
+
+        // then
+        assertThat(foundToken).isNull();
+    }
+    
+    @Test
+    @DisplayName("RefreshToken 삭제 테스트_성공")
+    void testDeleteByEmail_Success() {
+        // given
+        refreshTokenRepository.save(TEST_EMAIL, TEST_REFRESH_TOKEN);
+        assertThat(refreshTokenRepository.findByEmail(TEST_EMAIL)).isNotNull();
+
+        // when
+        refreshTokenRepository.deleteByEmail(TEST_EMAIL);
+
+        // then
+        String deletedToken = refreshTokenRepository.findByEmail(TEST_EMAIL);
+        assertThat(deletedToken).isNull();
+    }
+    
+    @Test
+    @DisplayName("존재하지 않는 이메일로 RefreshToken 삭제 테스트_실패")
+    void testDeleteByEmail_NotFound() {
+        // given
+        String nonExistentEmail = "nonexistent@test.com";
+        assertThat(refreshTokenRepository.findByEmail(nonExistentEmail)).isNull();
+
+        // when & then - 예외가 발생하지 않아야 함
+        refreshTokenRepository.deleteByEmail(nonExistentEmail);
+        assertThat(refreshTokenRepository.findByEmail(nonExistentEmail)).isNull();
+    }
+    
+    @Test
+    @DisplayName("RefreshToken 업데이트 테스트_성공")
+    void testUpdateRefreshToken_Success() {
+        // given
+        refreshTokenRepository.save(TEST_EMAIL, TEST_REFRESH_TOKEN);
+        String newRefreshToken = "new-refresh-token-99999";
+
+        // when
+        boolean result = refreshTokenRepository.save(TEST_EMAIL, newRefreshToken);
+
+        // then
+        assertThat(result).isTrue();
+        String updatedToken = refreshTokenRepository.findByEmail(TEST_EMAIL);
+        assertThat(updatedToken).isEqualTo(newRefreshToken);
+        assertThat(updatedToken).isNotEqualTo(TEST_REFRESH_TOKEN);
+    }
+    
+    @Test
+    @DisplayName("여러 사용자의 RefreshToken 저장 및 조회 테스트_성공")
+    void testMultipleUsers_Success() {
+        // given
+        refreshTokenRepository.save(TEST_EMAIL, TEST_REFRESH_TOKEN);
+        refreshTokenRepository.save(ANOTHER_EMAIL, ANOTHER_REFRESH_TOKEN);
+
+        // when
+        String token1 = refreshTokenRepository.findByEmail(TEST_EMAIL);
+        String token2 = refreshTokenRepository.findByEmail(ANOTHER_EMAIL);
+
+        // then
+        assertThat(token1).isEqualTo(TEST_REFRESH_TOKEN);
+        assertThat(token2).isEqualTo(ANOTHER_REFRESH_TOKEN);
+        assertThat(token1).isNotEqualTo(token2);
+    }
+    
+    @Test
+    @DisplayName("RefreshToken 저장 후 삭제 후 재저장 테스트_성공")
+    void testSaveDeleteSave_Success() {
+        // given
+        refreshTokenRepository.save(TEST_EMAIL, TEST_REFRESH_TOKEN);
+        refreshTokenRepository.deleteByEmail(TEST_EMAIL);
+        String newRefreshToken = "new-refresh-token-after-delete";
+
+        // when
+        refreshTokenRepository.save(TEST_EMAIL, newRefreshToken);
+
+        // then
+        String savedToken = refreshTokenRepository.findByEmail(TEST_EMAIL);
+        assertThat(savedToken).isEqualTo(newRefreshToken);
+        assertThat(savedToken).isNotEqualTo(TEST_REFRESH_TOKEN);
+    }
+}

--- a/src/test/java/com/homesweet/homesweetback/domain/auth/repository/UserRepositoryTest.java
+++ b/src/test/java/com/homesweet/homesweetback/domain/auth/repository/UserRepositoryTest.java
@@ -1,0 +1,136 @@
+package com.homesweet.homesweetback.domain.auth.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.homesweet.homesweetback.common.config.QueryDslConfig;
+import com.homesweet.homesweetback.domain.auth.entity.OAuth2Provider;
+import com.homesweet.homesweetback.domain.auth.entity.User;
+import com.homesweet.homesweetback.domain.auth.entity.UserRole;
+import com.homesweet.homesweetback.domain.product.category.repository.impl.ProductCategoryRepositoryImpl;
+import com.homesweet.homesweetback.domain.product.category.repository.mapper.ProductCategoryMapper;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@DisplayName("UserRepository 테스트")
+@Import({
+    QueryDslConfig.class,
+    ProductCategoryRepositoryImpl.class,
+    ProductCategoryMapper.class
+})
+class UserRepositoryTest {
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("UserRole.USER 권한을 가진 사용자 조회 테스트_성공")
+    void testFindAllByRoleUser_Success() {
+        // given
+        User user = createTestUser(UserRole.USER);
+        userRepository.save(user);
+
+        // when
+        List<User> users = userRepository.findAllByRole(UserRole.USER);
+
+        // then
+        assertThat(users).isNotEmpty();
+        assertThat(users.size()).isEqualTo(1);
+        assertThat(users.get(0).getRole()).isEqualTo(UserRole.USER);
+        assertThat(users.get(0).getProvider()).isEqualTo(OAuth2Provider.GOOGLE);
+        assertThat(users.get(0).getProviderId()).isEqualTo("123456789");
+    }
+
+    @Test
+    @DisplayName("UserRole.SELLER 권한을 가진 사용자 조회 테스트_성공")
+    void testFindAllByRoleSeller_Success() {
+        // given
+        User user = createTestUser(UserRole.SELLER);
+        userRepository.save(user);
+
+        // when
+        List<User> users = userRepository.findAllByRole(UserRole.SELLER);
+
+        // then
+        assertThat(users).isNotEmpty();
+        assertThat(users.size()).isEqualTo(1);
+        assertThat(users.get(0).getRole()).isEqualTo(UserRole.SELLER);
+        assertThat(users.get(0).getProvider()).isEqualTo(OAuth2Provider.GOOGLE);
+        assertThat(users.get(0).getProviderId()).isEqualTo("123456789");
+    }
+
+    @Test
+    @DisplayName("UserRole.USER 권한을 가진 사용자 조회 테스트_실패")
+    void testFindAllByRoleUser_Fail() {
+        // given
+        User user = createTestUser(UserRole.SELLER);
+        userRepository.save(user);
+
+        // when
+        List<User> users = userRepository.findAllByRole(UserRole.USER);
+
+        // then
+        assertThat(users).isEmpty();
+    }
+
+    @Test
+    @DisplayName("UserRole.SELLER 권한을 가진 사용자 조회 테스트_실패")
+    void testFindAllByRoleSeller_Fail() {
+        // given
+        User user = createTestUser(UserRole.USER);
+        userRepository.save(user);
+
+        // when
+        List<User> users = userRepository.findAllByRole(UserRole.SELLER);
+
+        // then
+        assertThat(users).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Provider와 ProviderId로 사용자 조회 테스트_성공")
+    void testFindByProviderAndProviderId_Success() {
+        // given
+        User user = createTestUser(UserRole.USER);
+        userRepository.save(user);
+
+        // when
+        Optional<User> foundUser = userRepository.findByProviderAndProviderId(OAuth2Provider.GOOGLE, "123456789");
+
+        // then
+        assertThat(foundUser).isPresent();
+        assertThat(foundUser.get().getRole()).isEqualTo(UserRole.USER);
+        assertThat(foundUser.get().getProvider()).isEqualTo(OAuth2Provider.GOOGLE);
+        assertThat(foundUser.get().getProviderId()).isEqualTo("123456789");
+    }
+
+    @Test
+    @DisplayName("Provider와 ProviderId로 사용자 조회 테스트_실패")
+    void testFindByProviderAndProviderId_Fail() {
+        // given
+        // when
+        Optional<User> foundUser = userRepository.findByProviderAndProviderId(OAuth2Provider.GOOGLE, "987654321");
+
+        // then
+        assertThat(foundUser).isEmpty();
+    }
+
+    private User createTestUser(UserRole role) {
+        return User.builder()
+                .email("test@test.com")
+                .name("test")
+                .role(role)
+                .provider(OAuth2Provider.GOOGLE)
+                .providerId("123456789")
+                .build();
+    }
+}

--- a/src/test/java/com/homesweet/homesweetback/domain/auth/service/AuthServiceIntegrationTest.java
+++ b/src/test/java/com/homesweet/homesweetback/domain/auth/service/AuthServiceIntegrationTest.java
@@ -1,0 +1,559 @@
+package com.homesweet.homesweetback.domain.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.homesweet.homesweetback.common.exception.BusinessException;
+import com.homesweet.homesweetback.common.exception.ErrorCode;
+import com.homesweet.homesweetback.common.security.jwt.JwtTokenProvider;
+import com.homesweet.homesweetback.common.util.CookieUtil;
+import com.homesweet.homesweetback.domain.auth.dto.AccessTokenResponse;
+import com.homesweet.homesweetback.domain.auth.dto.SignUpResponse;
+import com.homesweet.homesweetback.domain.auth.dto.SignupRequest;
+import com.homesweet.homesweetback.domain.auth.entity.OAuth2Provider;
+import com.homesweet.homesweetback.domain.auth.entity.User;
+import com.homesweet.homesweetback.domain.auth.entity.UserRole;
+import com.homesweet.homesweetback.domain.auth.repository.RefreshTokenRepository;
+import com.homesweet.homesweetback.domain.auth.repository.UserRepository;
+
+import jakarta.servlet.http.Cookie;
+
+/**
+ * AuthService 통합 테스트
+ * - 실제 DB(H2)를 사용하여 전체 플로우 검증
+ * - 실제 JWT 토큰 생성 및 검증
+ * - 트랜잭션 롤백으로 테스트 격리 보장
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+@DisplayName("AuthService 통합 테스트")
+class AuthServiceIntegrationTest {
+
+    @Autowired
+    private AuthService authService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private CookieUtil cookieUtil;
+
+    private User testUser;
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트용 사용자 생성
+        testUser = createTestUser(
+                "test@example.com",
+                "테스트유저",
+                UserRole.USER,
+                "123456789",
+                null,
+                null,
+                null
+        );
+
+        // Mock HTTP 요청/응답 초기화
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+    }
+
+    @Test
+    @DisplayName("refreshToken() 테스트_성공")
+    void testRefreshToken_Success() {
+        // given
+        String refreshToken = jwtTokenProvider.createRefreshToken(testUser);
+        refreshTokenRepository.save(testUser.getEmail(), refreshToken);
+        
+        Cookie cookie = cookieUtil.createRefreshTokenCookie(refreshToken);
+        request.setCookies(cookie);
+
+        // when
+        AccessTokenResponse result = authService.refreshToken(request, response);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.accessToken()).isNotNull();
+        assertThat(result.userResponse()).isNotNull();
+        assertThat(result.userResponse().id()).isEqualTo(testUser.getId());
+        assertThat(result.userResponse().email()).isEqualTo("test@example.com");
+        
+        // 새로운 Refresh Token이 Cookie에 설정되었는지 확인
+        Cookie[] cookies = response.getCookies();
+        assertThat(cookies).isNotEmpty();
+        boolean hasRefreshToken = false;
+        String newRefreshTokenFromCookie = null;
+        for (Cookie c : cookies) {
+            if ("refresh_token".equals(c.getName())) {
+                hasRefreshToken = true;
+                newRefreshTokenFromCookie = c.getValue();
+                assertThat(newRefreshTokenFromCookie).isNotNull();
+                break;
+            }
+        }
+        assertThat(hasRefreshToken).isTrue();
+        
+        // 새로운 Refresh Token이 저장되었는지 확인
+        String storedToken = refreshTokenRepository.findByEmail(testUser.getEmail());
+        assertThat(storedToken).isNotNull();
+        
+        // Cookie의 새 토큰과 저장된 토큰이 일치하는지 확인
+        if (newRefreshTokenFromCookie != null) {
+            assertThat(storedToken).isEqualTo(newRefreshTokenFromCookie);
+            // 새로운 토큰이 유효한지 확인
+            assertThat(jwtTokenProvider.validateToken(newRefreshTokenFromCookie)).isTrue();
+            assertThat(jwtTokenProvider.isRefreshToken(newRefreshTokenFromCookie)).isTrue();
+        }
+    }
+
+    @Test
+    @DisplayName("refreshToken() 테스트_실패_RefreshToken 없음")
+    void testRefreshToken_Fail_RefreshTokenNotFound() {
+        // given - Cookie 없음
+        request.setCookies();
+
+        // when & then
+        assertThatThrownBy(() -> authService.refreshToken(request, response))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("refreshToken() 테스트_실패_유효하지 않은 RefreshToken")
+    void testRefreshToken_Fail_InvalidRefreshToken() {
+        // given
+        String invalidToken = "invalid-token";
+        Cookie cookie = new Cookie("refresh_token", invalidToken);
+        request.setCookies(cookie);
+
+        // when & then
+        assertThatThrownBy(() -> authService.refreshToken(request, response))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN);
+        
+        // Cookie 삭제가 설정되었는지 확인
+        Cookie[] cookies = response.getCookies();
+        assertThat(cookies).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("refreshToken() 테스트_실패_저장된 RefreshToken과 불일치")
+    void testRefreshToken_Fail_StoredTokenMismatch() {
+        // given
+        String refreshToken = jwtTokenProvider.createRefreshToken(testUser);
+        // 다른 토큰을 저장
+        refreshTokenRepository.save(testUser.getEmail(), "different-token");
+        
+        Cookie cookie = cookieUtil.createRefreshTokenCookie(refreshToken);
+        request.setCookies(cookie);
+
+        // when & then
+        assertThatThrownBy(() -> authService.refreshToken(request, response))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN);
+    }
+
+    @Test
+    @DisplayName("saveOrUpdateOAuth2User() 테스트_성공_새 사용자 저장")
+    void testSaveOrUpdateOAuth2User_Success_NewUser() {
+        // given
+        User newUser = User.builder()
+                .email("newuser@example.com")
+                .name("새사용자")
+                .role(null) // null로 설정하여 기본값 USER가 적용되는지 확인
+                .provider(OAuth2Provider.GOOGLE)
+                .providerId("google-999")
+                .build();
+
+        // when
+        User result = authService.saveOrUpdateOAuth2User(newUser);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isNotNull();
+        assertThat(result.getEmail()).isEqualTo("newuser@example.com");
+        assertThat(result.getName()).isEqualTo("새사용자");
+        assertThat(result.getRole()).isEqualTo(UserRole.USER); // 기본값 적용 확인
+        assertThat(result.getProvider()).isEqualTo(OAuth2Provider.GOOGLE);
+        assertThat(result.getProviderId()).isEqualTo("google-999");
+        
+        // DB에서 실제로 저장되었는지 확인
+        User savedUser = userRepository.findById(result.getId()).orElseThrow();
+        assertThat(savedUser.getEmail()).isEqualTo("newuser@example.com");
+    }
+
+    @Test
+    @DisplayName("saveOrUpdateOAuth2User() 테스트_성공_기존 사용자 업데이트")
+    void testSaveOrUpdateOAuth2User_Success_UpdateExistingUser() {
+        // given
+        User existingUser = createTestUser(
+                "existing@example.com",
+                "기존사용자",
+                UserRole.USER,
+                "google-888",
+                null,
+                null,
+                null
+        );
+        
+        User updateUser = User.builder()
+                .email("updated@example.com")
+                .name("업데이트된사용자")
+                .role(UserRole.SELLER) // Role은 변경되지 않아야 함
+                .provider(OAuth2Provider.GOOGLE)
+                .providerId("google-888")
+                .profileImageUrl("https://new-image.com/image.jpg")
+                .build();
+
+        // when
+        User result = authService.saveOrUpdateOAuth2User(updateUser);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(existingUser.getId());
+        assertThat(result.getEmail()).isEqualTo("updated@example.com");
+        assertThat(result.getName()).isEqualTo("업데이트된사용자");
+        assertThat(result.getRole()).isEqualTo(UserRole.USER); // 기존 Role 유지
+        assertThat(result.getProviderId()).isEqualTo("google-888");
+        
+        // DB에서 실제로 업데이트되었는지 확인
+        User updatedUser = userRepository.findById(existingUser.getId()).orElseThrow();
+        assertThat(updatedUser.getEmail()).isEqualTo("updated@example.com");
+        assertThat(updatedUser.getName()).isEqualTo("업데이트된사용자");
+        assertThat(updatedUser.getRole()).isEqualTo(UserRole.USER);
+    }
+
+    @Test
+    @DisplayName("saveOrUpdateOAuth2User() 테스트_성공_프로필 이미지가 없을 때만 업데이트")
+    void testSaveOrUpdateOAuth2User_Success_ProfileImageUpdate() {
+        // given
+        User existingUser = createTestUser(
+                "image@example.com",
+                "이미지사용자",
+                UserRole.USER,
+                "google-777",
+                null,
+                null,
+                null
+        );
+        existingUser.setProfileImageUrl("https://old-image.com/image.jpg");
+        existingUser = userRepository.save(existingUser);
+        
+        User updateUser = User.builder()
+                .email("image@example.com")
+                .name("이미지사용자")
+                .provider(OAuth2Provider.GOOGLE)
+                .providerId("google-777")
+                .profileImageUrl("https://new-image.com/image.jpg")
+                .build();
+
+        // when
+        User result = authService.saveOrUpdateOAuth2User(updateUser);
+
+        // then
+        // 기존 이미지가 있으면 유지되어야 함
+        assertThat(result.getProfileImageUrl()).isEqualTo("https://old-image.com/image.jpg");
+        
+        // 기존 이미지가 없으면 새 이미지로 업데이트
+        existingUser.setProfileImageUrl(null);
+        existingUser = userRepository.save(existingUser);
+        User result2 = authService.saveOrUpdateOAuth2User(updateUser);
+        assertThat(result2.getProfileImageUrl()).isEqualTo("https://new-image.com/image.jpg");
+    }
+
+    @Test
+    @DisplayName("completeSignup() 테스트_성공")
+    void testCompleteSignup_Success() {
+        // given
+        String refreshToken = jwtTokenProvider.createRefreshToken(testUser);
+        refreshTokenRepository.save(testUser.getEmail(), refreshToken);
+        
+        Cookie cookie = cookieUtil.createRefreshTokenCookie(refreshToken);
+        request.setCookies(cookie);
+        
+        SignupRequest signupRequest = new SignupRequest(
+                "010-1234-5678",
+                LocalDate.of(1990, 1, 1),
+                "서울시 강남구"
+        );
+
+        // when
+        SignUpResponse result = authService.completeSignup(signupRequest, request, response);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.accessToken()).isNotNull();
+        assertThat(result.userResponse()).isNotNull();
+        assertThat(result.userResponse().id()).isEqualTo(testUser.getId());
+        assertThat(result.userResponse().phoneNumber()).isEqualTo("010-1234-5678");
+        assertThat(result.userResponse().birthDate()).isEqualTo(LocalDate.of(1990, 1, 1));
+        assertThat(result.userResponse().address()).isEqualTo("서울시 강남구");
+        
+        // DB에서 실제로 업데이트되었는지 확인
+        User updatedUser = userRepository.findById(testUser.getId()).orElseThrow();
+        assertThat(updatedUser.getPhoneNumber()).isEqualTo("010-1234-5678");
+        assertThat(updatedUser.getBirthDate()).isEqualTo(LocalDate.of(1990, 1, 1));
+        assertThat(updatedUser.getAddress()).isEqualTo("서울시 강남구");
+        
+        // 새로운 Refresh Token이 Cookie에 설정되었는지 확인
+        Cookie[] cookies = response.getCookies();
+        assertThat(cookies).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("completeSignup() 테스트_실패_생일이 미래 날짜")
+    void testCompleteSignup_Fail_FutureBirthDate() {
+        // given
+        String refreshToken = jwtTokenProvider.createRefreshToken(testUser);
+        refreshTokenRepository.save(testUser.getEmail(), refreshToken);
+        
+        Cookie cookie = cookieUtil.createRefreshTokenCookie(refreshToken);
+        request.setCookies(cookie);
+        
+        SignupRequest signupRequest = new SignupRequest(
+                "010-1234-5678",
+                LocalDate.now().plusDays(1), // 미래 날짜
+                "서울시 강남구"
+        );
+
+        // when & then
+        assertThatThrownBy(() -> authService.completeSignup(signupRequest, request, response))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_BIRTH_DATE);
+        
+        // DB에서 업데이트되지 않았는지 확인
+        User user = userRepository.findById(testUser.getId()).orElseThrow();
+        assertThat(user.getPhoneNumber()).isNull();
+        assertThat(user.getBirthDate()).isNull();
+    }
+
+    @Test
+    @DisplayName("completeSignup() 테스트_실패_RefreshToken 없음")
+    void testCompleteSignup_Fail_RefreshTokenNotFound() {
+        // given
+        request.setCookies();
+        
+        SignupRequest signupRequest = new SignupRequest(
+                "010-1234-5678",
+                LocalDate.of(1990, 1, 1),
+                "서울시 강남구"
+        );
+
+        // when & then
+        assertThatThrownBy(() -> authService.completeSignup(signupRequest, request, response))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("completeSignup() 테스트_실패_RefreshToken 유효하지 않음")
+    void testCompleteSignup_Fail_InvalidRefreshToken() {
+        // given
+        String invalidToken = "invalid-token";
+        Cookie cookie = new Cookie("refresh_token", invalidToken);
+        request.setCookies(cookie);
+        
+        SignupRequest signupRequest = new SignupRequest(
+                "010-1234-5678",
+                LocalDate.of(1990, 1, 1),
+                "서울시 강남구"
+        );
+
+        // when & then
+        assertThatThrownBy(() -> authService.completeSignup(signupRequest, request, response))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN);
+    }
+
+
+    @Test
+    @DisplayName("logout() 테스트_성공")
+    void testLogout_Success() {
+        // given
+        String accessToken = jwtTokenProvider.createAccessToken(testUser);
+        String refreshToken = jwtTokenProvider.createRefreshToken(testUser);
+        refreshTokenRepository.save(testUser.getEmail(), refreshToken);
+        
+        request.addHeader("Authorization", "Bearer " + accessToken);
+        Cookie cookie = cookieUtil.createRefreshTokenCookie(refreshToken);
+        request.setCookies(cookie);
+
+        // when
+        authService.logout(request, response);
+
+        // then
+        // Refresh Token이 삭제되었는지 확인
+        String storedToken = refreshTokenRepository.findByEmail(testUser.getEmail());
+        assertThat(storedToken).isNull();
+        
+        // Cookie 삭제가 설정되었는지 확인
+        Cookie[] cookies = response.getCookies();
+        assertThat(cookies).isNotEmpty();
+        boolean hasDeleteCookie = false;
+        for (Cookie c : cookies) {
+            if ("refresh_token".equals(c.getName()) && c.getMaxAge() == 0) {
+                hasDeleteCookie = true;
+                break;
+            }
+        }
+        assertThat(hasDeleteCookie).isTrue();
+    }
+
+    @Test
+    @DisplayName("logout() 테스트_성공_Authorization 헤더 없음")
+    void testLogout_Success_NoAuthorizationHeader() {
+        // given
+        String refreshToken = jwtTokenProvider.createRefreshToken(testUser);
+        refreshTokenRepository.save(testUser.getEmail(), refreshToken);
+        
+        Cookie cookie = cookieUtil.createRefreshTokenCookie(refreshToken);
+        request.setCookies(cookie);
+        // Authorization 헤더 없음
+
+        // when
+        authService.logout(request, response);
+
+        // then
+        // Refresh Token은 삭제되지 않음 (Authorization 헤더가 없으므로)
+        String storedToken = refreshTokenRepository.findByEmail(testUser.getEmail());
+        assertThat(storedToken).isNotNull();
+        
+        // Cookie 삭제는 설정됨
+        Cookie[] cookies = response.getCookies();
+        assertThat(cookies).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("logout() 테스트_성공_유효하지 않은 AccessToken")
+    void testLogout_Success_InvalidAccessToken() {
+        // given
+        String refreshToken = jwtTokenProvider.createRefreshToken(testUser);
+        refreshTokenRepository.save(testUser.getEmail(), refreshToken);
+        
+        request.addHeader("Authorization", "Bearer invalid-token");
+        Cookie cookie = cookieUtil.createRefreshTokenCookie(refreshToken);
+        request.setCookies(cookie);
+
+        // when
+        authService.logout(request, response);
+
+        // then
+        // Refresh Token은 삭제되지 않음 (유효하지 않은 토큰이므로)
+        String storedToken = refreshTokenRepository.findByEmail(testUser.getEmail());
+        assertThat(storedToken).isNotNull();
+        
+        // Cookie 삭제는 설정됨
+        Cookie[] cookies = response.getCookies();
+        assertThat(cookies).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("전체 플로우 테스트_OAuth2 사용자 생성부터 회원가입 완료까지")
+    void testFullFlow_OAuth2SignupToComplete() {
+        // 1. OAuth2 사용자 생성
+        User oauthUser = User.builder()
+                .email("oauth@example.com")
+                .name("OAuth사용자")
+                .provider(OAuth2Provider.GOOGLE)
+                .providerId("google-555")
+                .build();
+        
+        User savedOAuthUser = authService.saveOrUpdateOAuth2User(oauthUser);
+        assertThat(savedOAuthUser.getId()).isNotNull();
+        assertThat(savedOAuthUser.getRole()).isEqualTo(UserRole.USER);
+
+        // 2. Refresh Token 생성 및 저장
+        String refreshToken = jwtTokenProvider.createRefreshToken(savedOAuthUser);
+        refreshTokenRepository.save(savedOAuthUser.getEmail(), refreshToken);
+        
+        Cookie cookie = cookieUtil.createRefreshTokenCookie(refreshToken);
+        request.setCookies(cookie);
+
+        // 3. 회원가입 완료 (getUserFromRefreshToken은 내부적으로 호출됨)
+        SignupRequest signupRequest = new SignupRequest(
+                "010-9999-8888",
+                LocalDate.of(1995, 5, 15),
+                "부산시 해운대구"
+        );
+        
+        SignUpResponse signupResponse = authService.completeSignup(signupRequest, request, response);
+        assertThat(signupResponse.userResponse().phoneNumber()).isEqualTo("010-9999-8888");
+        assertThat(signupResponse.userResponse().address()).isEqualTo("부산시 해운대구");
+
+        // 5. 새로운 Refresh Token으로 토큰 갱신
+        Cookie[] cookies = response.getCookies();
+        String newRefreshToken = null;
+        for (Cookie c : cookies) {
+            if ("refresh_token".equals(c.getName())) {
+                newRefreshToken = c.getValue();
+                break;
+            }
+        }
+        assertThat(newRefreshToken).isNotNull();
+        
+        request.setCookies(cookieUtil.createRefreshTokenCookie(newRefreshToken));
+        AccessTokenResponse tokenResponse = authService.refreshToken(request, response);
+        assertThat(tokenResponse.accessToken()).isNotNull();
+
+        // 6. 로그아웃
+        request.addHeader("Authorization", "Bearer " + tokenResponse.accessToken());
+        authService.logout(request, response);
+        
+        // Refresh Token이 삭제되었는지 확인
+        String storedToken = refreshTokenRepository.findByEmail(savedOAuthUser.getEmail());
+        assertThat(storedToken).isNull();
+    }
+
+    /**
+     * 테스트용 사용자 생성 헬퍼 메서드
+     */
+    private User createTestUser(
+            String email,
+            String name,
+            UserRole role,
+            String providerId,
+            String phoneNumber,
+            String address,
+            LocalDate birthDate
+    ) {
+        User user = User.builder()
+                .email(email)
+                .name(name)
+                .role(role)
+                .provider(OAuth2Provider.GOOGLE)
+                .providerId(providerId)
+                .phoneNumber(phoneNumber)
+                .address(address)
+                .birthDate(birthDate)
+                .build();
+        return userRepository.save(user);
+    }
+}
+

--- a/src/test/java/com/homesweet/homesweetback/domain/auth/service/AuthServiceIntegrationTest.java
+++ b/src/test/java/com/homesweet/homesweetback/domain/auth/service/AuthServiceIntegrationTest.java
@@ -430,22 +430,21 @@ class AuthServiceIntegrationTest {
     @DisplayName("logout() 테스트_성공_Authorization 헤더 없음")
     void testLogout_Success_NoAuthorizationHeader() {
         // given
+        // Authorization 헤더 없이 Refresh Token만 있음
         String refreshToken = jwtTokenProvider.createRefreshToken(testUser);
         refreshTokenRepository.save(testUser.getEmail(), refreshToken);
         
         Cookie cookie = cookieUtil.createRefreshTokenCookie(refreshToken);
         request.setCookies(cookie);
-        // Authorization 헤더 없음
 
         // when
         authService.logout(request, response);
 
-        // then
-        // Refresh Token은 삭제되지 않음 (Authorization 헤더가 없으므로)
+        // then Refresh Token이 삭제되었는지 확인
         String storedToken = refreshTokenRepository.findByEmail(testUser.getEmail());
-        assertThat(storedToken).isNotNull();
+        assertThat(storedToken).isNull();
         
-        // Cookie 삭제는 설정됨
+        // Cookie 삭제가 설정되었는지 확인
         Cookie[] cookies = response.getCookies();
         assertThat(cookies).isNotEmpty();
     }
@@ -465,11 +464,11 @@ class AuthServiceIntegrationTest {
         authService.logout(request, response);
 
         // then
-        // Refresh Token은 삭제되지 않음 (유효하지 않은 토큰이므로)
+        // Refresh Token이 삭제되었는지 확인
         String storedToken = refreshTokenRepository.findByEmail(testUser.getEmail());
-        assertThat(storedToken).isNotNull();
+        assertThat(storedToken).isNull();
         
-        // Cookie 삭제는 설정됨
+        // Cookie 삭제가 설정되었는지 확인
         Cookie[] cookies = response.getCookies();
         assertThat(cookies).isNotEmpty();
     }

--- a/src/test/java/com/homesweet/homesweetback/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/homesweet/homesweetback/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,423 @@
+package com.homesweet.homesweetback.domain.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.homesweet.homesweetback.common.exception.BusinessException;
+import com.homesweet.homesweetback.common.exception.ErrorCode;
+import com.homesweet.homesweetback.common.security.jwt.JwtTokenProvider;
+import com.homesweet.homesweetback.common.util.CookieUtil;
+import com.homesweet.homesweetback.domain.auth.dto.AccessTokenResponse;
+import com.homesweet.homesweetback.domain.auth.dto.SignUpResponse;
+import com.homesweet.homesweetback.domain.auth.dto.SignupRequest;
+import com.homesweet.homesweetback.domain.auth.entity.OAuth2Provider;
+import com.homesweet.homesweetback.domain.auth.entity.User;
+import com.homesweet.homesweetback.domain.auth.entity.UserRole;
+import com.homesweet.homesweetback.domain.auth.repository.RefreshTokenRepository;
+import com.homesweet.homesweetback.domain.auth.repository.UserRepository;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AuthService 테스트")
+class AuthServiceTest {
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private CookieUtil cookieUtil;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Test
+    @DisplayName("refreshToken() 메서드 테스트_성공")
+    void testRefreshToken_Success() {
+        // given
+        Long userId = 1L;
+        String refreshToken = "valid-refresh-token";
+        String newAccessToken = "new-access-token";
+        String newRefreshToken = "new-refresh-token";
+        User user = createTestUser(userId, "test@test.com", UserRole.USER);
+        Cookie cookie = new Cookie("refresh_token", refreshToken);
+
+        given(cookieUtil.getRefreshTokenFromCookie(request)).willReturn(refreshToken);
+        given(jwtTokenProvider.validateToken(refreshToken)).willReturn(true);
+        given(jwtTokenProvider.isRefreshToken(refreshToken)).willReturn(true);
+        given(jwtTokenProvider.getUserIdFromToken(refreshToken)).willReturn(userId);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(refreshTokenRepository.findByEmail(user.getEmail())).willReturn(refreshToken);
+        given(jwtTokenProvider.createAccessToken(user)).willReturn(newAccessToken);
+        given(jwtTokenProvider.createRefreshToken(user)).willReturn(newRefreshToken);
+        given(refreshTokenRepository.save(user.getEmail(), newRefreshToken)).willReturn(true);
+        given(cookieUtil.createRefreshTokenCookie(newRefreshToken)).willReturn(cookie);
+
+        // when
+        AccessTokenResponse result = authService.refreshToken(request, response);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.accessToken()).isEqualTo(newAccessToken);
+        assertThat(result.userResponse()).isNotNull();
+        assertThat(result.userResponse().id()).isEqualTo(userId);
+        verify(cookieUtil, times(1)).getRefreshTokenFromCookie(request);
+        verify(jwtTokenProvider, times(1)).validateToken(refreshToken);
+        verify(jwtTokenProvider, times(1)).isRefreshToken(refreshToken);
+        verify(jwtTokenProvider, times(1)).getUserIdFromToken(refreshToken);
+        verify(userRepository, times(1)).findById(userId);
+        verify(refreshTokenRepository, times(1)).findByEmail(user.getEmail());
+        verify(jwtTokenProvider, times(1)).createAccessToken(user);
+        verify(jwtTokenProvider, times(1)).createRefreshToken(user);
+        verify(refreshTokenRepository, times(1)).save(user.getEmail(), newRefreshToken);
+        verify(cookieUtil, times(1)).createRefreshTokenCookie(newRefreshToken);
+        verify(response, times(1)).addCookie(cookie);
+    }
+
+    @Test
+    @DisplayName("refreshToken() 메서드 테스트_실패_RefreshToken 없음")
+    void testRefreshToken_Fail_RefreshTokenNotFound() {
+        // given
+        given(cookieUtil.getRefreshTokenFromCookie(request)).willReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> authService.refreshToken(request, response))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("Refresh Token을 찾을 수 없습니다");
+        verify(cookieUtil, times(1)).getRefreshTokenFromCookie(request);
+        verify(jwtTokenProvider, never()).validateToken(anyString());
+    }
+
+    @Test
+    @DisplayName("refreshToken() 메서드 테스트_실패_유효하지 않은 RefreshToken")
+    void testRefreshToken_Fail_InvalidRefreshToken() {
+        // given
+        String refreshToken = "invalid-refresh-token";
+        Cookie deleteCookie = new Cookie("refresh_token", "");
+        given(cookieUtil.getRefreshTokenFromCookie(request)).willReturn(refreshToken);
+        given(jwtTokenProvider.validateToken(refreshToken)).willReturn(false);
+        given(cookieUtil.createRefreshTokenCookieForDeletion()).willReturn(deleteCookie);
+
+        // when & then
+        assertThatThrownBy(() -> authService.refreshToken(request, response))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("유효하지 않은 Refresh Token입니다");
+        verify(cookieUtil, times(1)).getRefreshTokenFromCookie(request);
+        verify(jwtTokenProvider, times(1)).validateToken(refreshToken);
+        verify(jwtTokenProvider, never()).isRefreshToken(anyString());
+        verify(cookieUtil, times(1)).createRefreshTokenCookieForDeletion();
+        verify(response, times(1)).addCookie(deleteCookie);
+    }
+
+    @Test
+    @DisplayName("refreshToken() 메서드 테스트_실패_RefreshToken 타입 아님")
+    void testRefreshToken_Fail_NotRefreshTokenType() {
+        // given
+        String refreshToken = "access-token";
+        Cookie deleteCookie = new Cookie("refresh_token", "");
+        given(cookieUtil.getRefreshTokenFromCookie(request)).willReturn(refreshToken);
+        given(jwtTokenProvider.validateToken(refreshToken)).willReturn(true);
+        given(jwtTokenProvider.isRefreshToken(refreshToken)).willReturn(false);
+        given(cookieUtil.createRefreshTokenCookieForDeletion()).willReturn(deleteCookie);
+
+        // when & then
+        assertThatThrownBy(() -> authService.refreshToken(request, response))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("유효하지 않은 Refresh Token입니다");
+        verify(cookieUtil, times(1)).getRefreshTokenFromCookie(request);
+        verify(jwtTokenProvider, times(1)).validateToken(refreshToken);
+        verify(jwtTokenProvider, times(1)).isRefreshToken(refreshToken);
+        verify(cookieUtil, times(1)).createRefreshTokenCookieForDeletion();
+        verify(response, times(1)).addCookie(deleteCookie);
+    }
+
+    @Test
+    @DisplayName("refreshToken() 메서드 테스트_실패_사용자 없음")
+    void testRefreshToken_Fail_UserNotFound() {
+        // given
+        Long userId = 999L;
+        String refreshToken = "valid-refresh-token";
+        given(cookieUtil.getRefreshTokenFromCookie(request)).willReturn(refreshToken);
+        given(jwtTokenProvider.validateToken(refreshToken)).willReturn(true);
+        given(jwtTokenProvider.isRefreshToken(refreshToken)).willReturn(true);
+        given(jwtTokenProvider.getUserIdFromToken(refreshToken)).willReturn(userId);
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> authService.refreshToken(request, response))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("해당하는 사용자를 찾을 수 없습니다");
+        verify(userRepository, times(1)).findById(userId);
+        verify(cookieUtil, never()).createRefreshTokenCookieForDeletion();
+    }
+
+    @Test
+    @DisplayName("refreshToken() 메서드 테스트_실패_저장된 RefreshToken과 불일치")
+    void testRefreshToken_Fail_StoredTokenMismatch() {
+        // given
+        Long userId = 1L;
+        String refreshToken = "valid-refresh-token";
+        String storedToken = "different-token";
+        User user = createTestUser(userId, "test@test.com", UserRole.USER);
+        given(cookieUtil.getRefreshTokenFromCookie(request)).willReturn(refreshToken);
+        given(jwtTokenProvider.validateToken(refreshToken)).willReturn(true);
+        given(jwtTokenProvider.isRefreshToken(refreshToken)).willReturn(true);
+        given(jwtTokenProvider.getUserIdFromToken(refreshToken)).willReturn(userId);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(refreshTokenRepository.findByEmail(user.getEmail())).willReturn(storedToken);
+
+        // when & then
+        assertThatThrownBy(() -> authService.refreshToken(request, response))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("유효하지 않은 Refresh Token입니다");
+        verify(refreshTokenRepository, times(1)).findByEmail(user.getEmail());
+        verify(cookieUtil, never()).createRefreshTokenCookieForDeletion();
+    }
+
+
+    @Test
+    @DisplayName("saveOrUpdateOAuth2User() 메서드 테스트_성공_새 사용자 저장")
+    void testSaveOrUpdateOAuth2User_Success_NewUser() {
+        // given
+        User newUser = createTestUser(null, "new@test.com", null);
+        newUser.setProvider(OAuth2Provider.GOOGLE);
+        newUser.setProviderId("google-123");
+        User savedUser = createTestUser(1L, "new@test.com", UserRole.USER);
+        savedUser.setProvider(OAuth2Provider.GOOGLE);
+        savedUser.setProviderId("google-123");
+
+        given(userRepository.findByProviderAndProviderId(OAuth2Provider.GOOGLE, "google-123"))
+                .willReturn(Optional.empty());
+        given(userRepository.save(any(User.class))).willReturn(savedUser);
+
+        // when
+        User result = authService.saveOrUpdateOAuth2User(newUser);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(1L);
+        assertThat(result.getEmail()).isEqualTo("new@test.com");
+        assertThat(result.getRole()).isEqualTo(UserRole.USER);
+        verify(userRepository, times(1)).findByProviderAndProviderId(OAuth2Provider.GOOGLE, "google-123");
+        verify(userRepository, times(1)).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("saveOrUpdateOAuth2User() 메서드 테스트_성공_기존 사용자 업데이트")
+    void testSaveOrUpdateOAuth2User_Success_UpdateExistingUser() {
+        // given
+        Long userId = 1L;
+        User existingUser = createTestUser(userId, "old@test.com", UserRole.USER);
+        existingUser.setProvider(OAuth2Provider.GOOGLE);
+        existingUser.setProviderId("google-123");
+        existingUser.setName("Old Name");
+        existingUser.setProfileImageUrl("https://old-image.com/image.jpg");
+
+        User updatedUser = createTestUser(userId, "new@test.com", UserRole.USER);
+        updatedUser.setProvider(OAuth2Provider.GOOGLE);
+        updatedUser.setProviderId("google-123");
+        updatedUser.setName("New Name");
+        updatedUser.setProfileImageUrl("https://new-image.com/image.jpg");
+
+        given(userRepository.findByProviderAndProviderId(OAuth2Provider.GOOGLE, "google-123"))
+                .willReturn(Optional.of(existingUser));
+        given(userRepository.save(existingUser)).willReturn(existingUser);
+
+        // when
+        User result = authService.saveOrUpdateOAuth2User(updatedUser);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(userId);
+        assertThat(result.getEmail()).isEqualTo("new@test.com");
+        assertThat(result.getName()).isEqualTo("New Name");
+        assertThat(result.getProfileImageUrl()).isEqualTo("https://old-image.com/image.jpg"); // 기존 이미지 유지
+        verify(userRepository, times(1)).findByProviderAndProviderId(OAuth2Provider.GOOGLE, "google-123");
+        verify(userRepository, times(1)).save(existingUser);
+    }
+
+    @Test
+    @DisplayName("completeSignup() 메서드 테스트_성공")
+    void testCompleteSignup_Success() {
+        // given
+        Long userId = 1L;
+        String refreshToken = "valid-refresh-token";
+        String newAccessToken = "new-access-token";
+        String newRefreshToken = "new-refresh-token";
+        User user = createTestUser(userId, "test@test.com", UserRole.USER);
+        SignupRequest signupRequest = new SignupRequest(
+                "010-1234-5678",
+                LocalDate.of(1990, 1, 1),
+                "서울시 강남구"
+        );
+        Cookie cookie = new Cookie("refresh_token", newRefreshToken);
+
+        given(cookieUtil.getRefreshTokenFromCookie(request)).willReturn(refreshToken);
+        given(jwtTokenProvider.validateToken(refreshToken)).willReturn(true);
+        given(jwtTokenProvider.isRefreshToken(refreshToken)).willReturn(true);
+        given(jwtTokenProvider.getUserIdFromToken(refreshToken)).willReturn(userId);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(userRepository.save(any(User.class))).willReturn(user);
+        given(jwtTokenProvider.createAccessToken(user)).willReturn(newAccessToken);
+        given(jwtTokenProvider.createRefreshToken(user)).willReturn(newRefreshToken);
+        given(refreshTokenRepository.save(user.getEmail(), newRefreshToken)).willReturn(true);
+        given(cookieUtil.createRefreshTokenCookie(newRefreshToken)).willReturn(cookie);
+
+        // when
+        SignUpResponse result = authService.completeSignup(signupRequest, request, response);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.accessToken()).isEqualTo(newAccessToken);
+        assertThat(result.userResponse()).isNotNull();
+        assertThat(result.userResponse().id()).isEqualTo(userId);
+        verify(userRepository, times(1)).save(any(User.class));
+        verify(jwtTokenProvider, times(1)).createAccessToken(user);
+        verify(jwtTokenProvider, times(1)).createRefreshToken(user);
+        verify(refreshTokenRepository, times(1)).save(user.getEmail(), newRefreshToken);
+        verify(cookieUtil, times(1)).createRefreshTokenCookie(newRefreshToken);
+        verify(response, times(1)).addCookie(cookie);
+    }
+
+    @Test
+    @DisplayName("completeSignup() 메서드 테스트_실패_생일이 미래 날짜")
+    void testCompleteSignup_Fail_FutureBirthDate() {
+        // given
+        Long userId = 1L;
+        String refreshToken = "valid-refresh-token";
+        User user = createTestUser(userId, "test@test.com", UserRole.USER);
+        SignupRequest signupRequest = new SignupRequest(
+                "010-1234-5678",
+                LocalDate.now().plusDays(1), // 미래 날짜
+                "서울시 강남구"
+        );
+
+        given(cookieUtil.getRefreshTokenFromCookie(request)).willReturn(refreshToken);
+        given(jwtTokenProvider.validateToken(refreshToken)).willReturn(true);
+        given(jwtTokenProvider.isRefreshToken(refreshToken)).willReturn(true);
+        given(jwtTokenProvider.getUserIdFromToken(refreshToken)).willReturn(userId);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        // when & then
+        assertThatThrownBy(() -> authService.completeSignup(signupRequest, request, response))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("생일은 미래 날짜가 될 수 없습니다")
+                .extracting("errorCode").isEqualTo(ErrorCode.INVALID_BIRTH_DATE);
+        verify(userRepository, never()).save(any(User.class));
+    }
+    
+
+    @Test
+    @DisplayName("logout() 메서드 테스트_성공")
+    void testLogout_Success() {
+        // given
+        String accessToken = "valid-access-token";
+        Long userId = 1L;
+        String email = "test@test.com";
+        Cookie deleteCookie = new Cookie("refresh_token", "");
+
+        given(request.getHeader("Authorization")).willReturn("Bearer " + accessToken);
+        given(jwtTokenProvider.validateToken(accessToken)).willReturn(true);
+        given(jwtTokenProvider.getUserIdFromToken(accessToken)).willReturn(userId);
+        given(jwtTokenProvider.getEmailFromToken(accessToken)).willReturn(email);
+        willDoNothing().given(refreshTokenRepository).deleteByEmail(email);
+        given(cookieUtil.createRefreshTokenCookieForDeletion()).willReturn(deleteCookie);
+
+        // when
+        authService.logout(request, response);
+
+        // then
+        verify(request, times(1)).getHeader("Authorization");
+        verify(jwtTokenProvider, times(1)).validateToken(accessToken);
+        verify(jwtTokenProvider, times(1)).getUserIdFromToken(accessToken);
+        verify(jwtTokenProvider, times(1)).getEmailFromToken(accessToken);
+        verify(refreshTokenRepository, times(1)).deleteByEmail(email);
+        verify(cookieUtil, times(1)).createRefreshTokenCookieForDeletion();
+        verify(response, times(1)).addCookie(deleteCookie);
+    }
+
+    @Test
+    @DisplayName("logout() 메서드 테스트_성공_Authorization 헤더 없음")
+    void testLogout_Success_NoAuthorizationHeader() {
+        // given
+        Cookie deleteCookie = new Cookie("refresh_token", "");
+        given(request.getHeader("Authorization")).willReturn(null);
+        given(cookieUtil.createRefreshTokenCookieForDeletion()).willReturn(deleteCookie);
+
+        // when
+        authService.logout(request, response);
+
+        // then
+        verify(request, times(1)).getHeader("Authorization");
+        verify(jwtTokenProvider, never()).validateToken(anyString());
+        verify(refreshTokenRepository, never()).deleteByEmail(anyString());
+        verify(cookieUtil, times(1)).createRefreshTokenCookieForDeletion();
+        verify(response, times(1)).addCookie(deleteCookie);
+    }
+
+    @Test
+    @DisplayName("logout() 메서드 테스트_성공_유효하지 않은 AccessToken")
+    void testLogout_Success_InvalidAccessToken() {
+        // given
+        String accessToken = "invalid-access-token";
+        Cookie deleteCookie = new Cookie("refresh_token", "");
+        given(request.getHeader("Authorization")).willReturn("Bearer " + accessToken);
+        given(jwtTokenProvider.validateToken(accessToken)).willReturn(false);
+        given(cookieUtil.createRefreshTokenCookieForDeletion()).willReturn(deleteCookie);
+
+        // when
+        authService.logout(request, response);
+
+        // then
+        verify(request, times(1)).getHeader("Authorization");
+        verify(jwtTokenProvider, times(1)).validateToken(accessToken);
+        verify(refreshTokenRepository, never()).deleteByEmail(anyString());
+        verify(cookieUtil, times(1)).createRefreshTokenCookieForDeletion();
+        verify(response, times(1)).addCookie(deleteCookie);
+    }
+
+    private User createTestUser(Long userId, String email, UserRole role) {
+        User user = User.builder()
+                .email(email)
+                .name("test")
+                .role(role != null ? role : UserRole.USER)
+                .provider(OAuth2Provider.GOOGLE)
+                .providerId("123456789")
+                .build();
+        if (userId != null) {
+            user.setId(userId);
+        }
+        return user;
+    }
+}

--- a/src/test/java/com/homesweet/homesweetback/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/homesweet/homesweetback/domain/auth/service/AuthServiceTest.java
@@ -371,8 +371,11 @@ class AuthServiceTest {
     @DisplayName("logout() 메서드 테스트_성공_Authorization 헤더 없음")
     void testLogout_Success_NoAuthorizationHeader() {
         // given
-        Cookie deleteCookie = new Cookie("refresh_token", "");
+        Cookie deleteCookie = new Cookie("refresh_token", "test-refresh-token");
         given(request.getHeader("Authorization")).willReturn(null);
+        given(cookieUtil.getRefreshTokenFromCookie(request)).willReturn("test-refresh-token");
+        given(jwtTokenProvider.validateToken("test-refresh-token")).willReturn(true);
+        willDoNothing().given(refreshTokenRepository).deleteByRefreshToken("test-refresh-token");
         given(cookieUtil.createRefreshTokenCookieForDeletion()).willReturn(deleteCookie);
 
         // when
@@ -380,8 +383,9 @@ class AuthServiceTest {
 
         // then
         verify(request, times(1)).getHeader("Authorization");
-        verify(jwtTokenProvider, never()).validateToken(anyString());
-        verify(refreshTokenRepository, never()).deleteByEmail(anyString());
+        verify(cookieUtil, times(1)).getRefreshTokenFromCookie(request);
+        verify(jwtTokenProvider, times(1)).validateToken("test-refresh-token");
+        verify(refreshTokenRepository, times(1)).deleteByRefreshToken("test-refresh-token");
         verify(cookieUtil, times(1)).createRefreshTokenCookieForDeletion();
         verify(response, times(1)).addCookie(deleteCookie);
     }
@@ -391,9 +395,13 @@ class AuthServiceTest {
     void testLogout_Success_InvalidAccessToken() {
         // given
         String accessToken = "invalid-access-token";
-        Cookie deleteCookie = new Cookie("refresh_token", "");
+        String refreshToken = "test-refresh-token";
+        Cookie deleteCookie = new Cookie("refresh_token", refreshToken);
         given(request.getHeader("Authorization")).willReturn("Bearer " + accessToken);
         given(jwtTokenProvider.validateToken(accessToken)).willReturn(false);
+        given(jwtTokenProvider.validateToken(refreshToken)).willReturn(true);
+        willDoNothing().given(refreshTokenRepository).deleteByRefreshToken("test-refresh-token");
+        given(cookieUtil.getRefreshTokenFromCookie(request)).willReturn(refreshToken);
         given(cookieUtil.createRefreshTokenCookieForDeletion()).willReturn(deleteCookie);
 
         // when
@@ -402,7 +410,8 @@ class AuthServiceTest {
         // then
         verify(request, times(1)).getHeader("Authorization");
         verify(jwtTokenProvider, times(1)).validateToken(accessToken);
-        verify(refreshTokenRepository, never()).deleteByEmail(anyString());
+        verify(jwtTokenProvider, times(1)).validateToken(refreshToken);
+        verify(refreshTokenRepository, times(1)).deleteByRefreshToken("test-refresh-token");
         verify(cookieUtil, times(1)).createRefreshTokenCookieForDeletion();
         verify(response, times(1)).addCookie(deleteCookie);
     }

--- a/src/test/java/com/homesweet/homesweetback/domain/auth/service/UserServiceIntegrationTest.java
+++ b/src/test/java/com/homesweet/homesweetback/domain/auth/service/UserServiceIntegrationTest.java
@@ -1,0 +1,542 @@
+package com.homesweet.homesweetback.domain.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.homesweet.homesweetback.common.s3.ImageUploader;
+import com.homesweet.homesweetback.domain.auth.dto.UpdateUserRequest;
+import com.homesweet.homesweetback.domain.auth.dto.UpdateUserRoleRequest;
+import com.homesweet.homesweetback.domain.auth.dto.UserResponse;
+import com.homesweet.homesweetback.domain.auth.entity.OAuth2Provider;
+import com.homesweet.homesweetback.domain.auth.entity.User;
+import com.homesweet.homesweetback.domain.auth.entity.UserRole;
+import com.homesweet.homesweetback.domain.auth.repository.UserRepository;
+import com.homesweet.homesweetback.domain.grade.entity.Grade;
+import com.homesweet.homesweetback.domain.grade.repository.GradeRepository;
+
+/**
+ * UserService 테스트
+ * - 실제 DB(H2)를 사용하여 전체 플로우 검증
+ * - 트랜잭션 롤백으로 테스트 격리 보장
+ * - ImageUploader는 MockitoBean으로 Mock 처리하여 S3 업로드 시뮬레이션
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("UserService 테스트")
+class UserServiceIntegrationTest {
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private GradeRepository gradeRepository;
+
+    @MockitoBean
+    private ImageUploader imageUploader;
+
+    private User testUser;
+    private Grade testGrade;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트용 사용자 생성
+        testUser = createTestUser(
+                "test@example.com",
+                "테스트유저",
+                UserRole.USER,
+                "123456789",
+                "010-1234-5678",
+                "서울시 강남구",
+                LocalDate.of(1990, 1, 1)
+        );
+
+        testGrade = gradeRepository.findById(1).orElseThrow();
+
+        // ImageUploader Mock 설정
+        when(imageUploader.upload(any(MultipartFile.class), anyString()))
+                .thenAnswer(invocation -> {
+                    String path = invocation.getArgument(1);
+                    return "https://test-bucket.s3.amazonaws.com/" + path + "/test-image.jpg";
+                });
+    }
+
+    @Test
+    @DisplayName("getUserInfo() 테스트_성공")
+    void testGetUserInfo_Success() {
+        // when
+        UserResponse response = userService.getUserInfo(testUser.getId());
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.id()).isEqualTo(testUser.getId());
+        assertThat(response.email()).isEqualTo("test@example.com");
+        assertThat(response.name()).isEqualTo("테스트유저");
+        assertThat(response.role()).isEqualTo(UserRole.USER);
+        assertThat(response.phoneNumber()).isEqualTo("010-1234-5678");
+        assertThat(response.address()).isEqualTo("서울시 강남구");
+        assertThat(response.birthDate()).isEqualTo(LocalDate.of(1990, 1, 1));
+    }
+
+    @Test
+    @DisplayName("getUserInfo() 테스트_실패_사용자 없음")
+    void testGetUserInfo_Fail_UserNotFound() {
+        // given
+        Long invalidUserId = 99999L;
+
+        // when & then
+        assertThatThrownBy(() -> userService.getUserInfo(invalidUserId))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("User not found with id: " + invalidUserId);
+    }
+
+    @Test
+    @DisplayName("updateUserInfo() 테스트_성공_이미지 없음")
+    void testUpdateUserInfo_Success_WithoutImage() {
+        // given
+        UpdateUserRequest request = new UpdateUserRequest(
+                "수정된이름",
+                "010-9876-5432",
+                LocalDate.of(1995, 5, 15),
+                "서울시 서초구"
+        );
+
+        // when
+        UserResponse response = userService.updateUserInfo(
+                testUser.getId(),
+                request,
+                Optional.empty()
+        );
+
+        // then
+        assertThat(response.name()).isEqualTo("수정된이름");
+        assertThat(response.phoneNumber()).isEqualTo("010-9876-5432");
+        assertThat(response.birthDate()).isEqualTo(LocalDate.of(1995, 5, 15));
+        assertThat(response.address()).isEqualTo("서울시 서초구");
+
+        // DB에서 실제로 업데이트되었는지 확인
+        User updatedUser = userRepository.findById(testUser.getId()).orElseThrow();
+        assertThat(updatedUser.getName()).isEqualTo("수정된이름");
+        assertThat(updatedUser.getPhoneNumber()).isEqualTo("010-9876-5432");
+        assertThat(updatedUser.getBirthDate()).isEqualTo(LocalDate.of(1995, 5, 15));
+        assertThat(updatedUser.getAddress()).isEqualTo("서울시 서초구");
+    }
+
+    @Test
+    @DisplayName("updateUserInfo() 테스트_성공_이미지 있음")
+    void testUpdateUserInfo_Success_WithImage() {
+        // given
+        testUser.setProfileImageUrl("https://old-image-url.com/image.jpg");
+        userRepository.save(testUser);
+
+        MockMultipartFile image = new MockMultipartFile(
+                "profileImage",
+                "new-profile.jpg",
+                "image/jpeg",
+                "test image content".getBytes()
+        );
+        UpdateUserRequest request = new UpdateUserRequest(
+                "이미지업데이트유저",
+                null,
+                null,
+                null
+        );
+
+        // when
+        UserResponse response = userService.updateUserInfo(
+                testUser.getId(),
+                request,
+                Optional.of(image)
+        );
+
+        // then
+        assertThat(response.name()).isEqualTo("이미지업데이트유저");
+        assertThat(response.profileImageUrl()).isNotNull();
+        assertThat(response.profileImageUrl()).contains("test-bucket.s3.amazonaws.com");
+
+        // DB에서 실제로 업데이트되었는지 확인
+        User updatedUser = userRepository.findById(testUser.getId()).orElseThrow();
+        assertThat(updatedUser.getName()).isEqualTo("이미지업데이트유저");
+        assertThat(updatedUser.getProfileImageUrl()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("updateUserInfo() 테스트_성공_부분 업데이트")
+    void testUpdateUserInfo_Success_PartialUpdate() {
+        // given
+        UpdateUserRequest request = new UpdateUserRequest(
+                "이름만수정",
+                null,
+                null,
+                null
+        );
+
+        // when
+        UserResponse response = userService.updateUserInfo(
+                testUser.getId(),
+                request,
+                Optional.empty()
+        );
+
+        // then
+        assertThat(response.name()).isEqualTo("이름만수정");
+        // 기존 값들은 유지되어야 함
+        assertThat(response.phoneNumber()).isEqualTo("010-1234-5678");
+        assertThat(response.address()).isEqualTo("서울시 강남구");
+
+        // DB 확인
+        User updatedUser = userRepository.findById(testUser.getId()).orElseThrow();
+        assertThat(updatedUser.getName()).isEqualTo("이름만수정");
+        assertThat(updatedUser.getPhoneNumber()).isEqualTo("010-1234-5678");
+    }
+
+    @Test
+    @DisplayName("updateUserInfo() 테스트_실패_사용자 없음")
+    void testUpdateUserInfo_Fail_UserNotFound() {
+        // given
+        Long invalidUserId = 99999L;
+        UpdateUserRequest request = new UpdateUserRequest(null, null, null, null);
+
+        // when & then
+        assertThatThrownBy(() -> userService.updateUserInfo(
+                invalidUserId,
+                request,
+                Optional.empty()
+        ))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("User not found with id: " + invalidUserId);
+    }
+
+    @Test
+    @DisplayName("updateUserInfo() 테스트_실패_핸드폰 번호 형식 오류")
+    void testUpdateUserInfo_Fail_InvalidPhoneNumber() {
+        // given
+        UpdateUserRequest request = new UpdateUserRequest(
+                null,
+                "123-456-789", // 잘못된 형식
+                null,
+                null
+        );
+
+        // when & then
+        assertThatThrownBy(() -> userService.updateUserInfo(
+                testUser.getId(),
+                request,
+                Optional.empty()
+        ))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("올바른 핸드폰 번호 형식이 아닙니다");
+    }
+
+    @Test
+    @DisplayName("deleteUser() 테스트_성공")
+    void testDeleteUser_Success() {
+        // given
+        Long userId = testUser.getId();
+
+        // when
+        userService.deleteUser(userId);
+
+        // then
+        Optional<User> deletedUser = userRepository.findById(userId);
+        assertThat(deletedUser).isEmpty();
+    }
+
+    @Test
+    @DisplayName("deleteUser() 테스트_실패_사용자 없음")
+    void testDeleteUser_Fail_UserNotFound() {
+        // given
+        Long invalidUserId = 99999L;
+
+        // when & then
+        assertThatThrownBy(() -> userService.deleteUser(invalidUserId))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("User not found with id: " + invalidUserId);
+    }
+
+    @Test
+    @DisplayName("updateUserRole() 테스트_성공")
+    void testUpdateUserRole_Success() {
+        // given
+        // setUp에서 이미 5개의 등급이 생성되어 있음
+        UpdateUserRoleRequest request = new UpdateUserRoleRequest(UserRole.SELLER);
+
+        // when
+        UserResponse response = userService.updateUserRole(testUser.getId(), request);
+
+        // then
+        assertThat(response.role()).isEqualTo(UserRole.SELLER);
+        assertThat(response.grade()).isNotNull();
+
+        // DB에서 실제로 업데이트되었는지 확인
+        User updatedUser = userRepository.findById(testUser.getId()).orElseThrow();
+        assertThat(updatedUser.getRole()).isEqualTo(UserRole.SELLER);
+        assertThat(updatedUser.getGrade()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("updateUserRole() 테스트_실패_사용자 없음")
+    void testUpdateUserRole_Fail_UserNotFound() {
+        // given
+        Long invalidUserId = 99999L;
+        UpdateUserRoleRequest request = new UpdateUserRoleRequest(UserRole.SELLER);
+
+        // when & then
+        assertThatThrownBy(() -> userService.updateUserRole(invalidUserId, request))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("User not found with id: " + invalidUserId);
+    }
+
+    @Test
+    @DisplayName("getUserGrade() 테스트_성공_등급 있음")
+    void testGetUserGrade_Success_WithGrade() {
+        // given
+        testUser.setGrade(testGrade);
+        userRepository.save(testUser);
+
+        // when
+        Optional<Grade> result = userService.getUserGrade(testUser.getId());
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().getGrade()).isEqualTo(testGrade.getGrade());
+        assertThat(result.get().getFeeRate()).isEqualByComparingTo(testGrade.getFeeRate());
+    }
+
+    @Test
+    @DisplayName("getUserGrade() 테스트_성공_등급 없음")
+    void testGetUserGrade_Success_WithoutGrade() {
+        // when
+        Optional<Grade> result = userService.getUserGrade(testUser.getId());
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("getUserGrade() 테스트_실패_사용자 없음")
+    void testGetUserGrade_Fail_UserNotFound() {
+        // given
+        Long invalidUserId = 99999L;
+
+        // when & then
+        assertThatThrownBy(() -> userService.getUserGrade(invalidUserId))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("User not found with id: " + invalidUserId);
+    }
+
+    @Test
+    @DisplayName("getUserGradeName() 테스트_성공_등급 있음")
+    void testGetUserGradeName_Success_WithGrade() {
+        // given
+        testUser.setGrade(testGrade);
+        userRepository.save(testUser);
+
+        // when
+        String gradeName = userService.getUserGradeName(testUser.getId());
+
+        // then
+        assertThat(gradeName).isEqualTo(testGrade.getGrade());
+    }
+
+    @Test
+    @DisplayName("getUserGradeName() 테스트_성공_등급 없음")
+    void testGetUserGradeName_Success_WithoutGrade() {
+        // when
+        String gradeName = userService.getUserGradeName(testUser.getId());
+
+        // then
+        assertThat(gradeName).isEqualTo("등급 없음");
+    }
+
+    @Test
+    @DisplayName("getUserGradeName() 테스트_실패_사용자 없음")
+    void testGetUserGradeName_Fail_UserNotFound() {
+        // given
+        Long invalidUserId = 99999L;
+
+        // when & then
+        assertThatThrownBy(() -> userService.getUserGradeName(invalidUserId))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("User not found with id: " + invalidUserId);
+    }
+
+    @Test
+    @DisplayName("getUserFeeRate() 테스트_성공_등급 있음")
+    void testGetUserFeeRate_Success_WithGrade() {
+        // given
+        testUser.setGrade(testGrade);
+        userRepository.save(testUser);
+
+        // when
+        BigDecimal feeRate = userService.getUserFeeRate(testUser.getId());
+
+        // then
+        assertThat(feeRate).isEqualByComparingTo(testGrade.getFeeRate());
+    }
+
+    @Test
+    @DisplayName("getUserFeeRate() 테스트_성공_등급 없음")
+    void testGetUserFeeRate_Success_WithoutGrade() {
+        // when
+        BigDecimal feeRate = userService.getUserFeeRate(testUser.getId());
+
+        // then
+        assertThat(feeRate).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    @Test
+    @DisplayName("getUserFeeRate() 테스트_실패_사용자 없음")
+    void testGetUserFeeRate_Fail_UserNotFound() {
+        // given
+        Long invalidUserId = 99999L;
+
+        // when & then
+        assertThatThrownBy(() -> userService.getUserFeeRate(invalidUserId))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("User not found with id: " + invalidUserId);
+    }
+
+    @Test
+    @DisplayName("hasUserGrade() 테스트_성공_등급 있음")
+    void testHasUserGrade_Success_WithGrade() {
+        // given
+        testUser.setGrade(testGrade);
+        userRepository.save(testUser);
+
+        // when
+        boolean result = userService.hasUserGrade(testUser.getId());
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("hasUserGrade() 테스트_성공_등급 없음")
+    void testHasUserGrade_Success_WithoutGrade() {
+        // when
+        boolean result = userService.hasUserGrade(testUser.getId());
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("hasUserGrade() 테스트_실패_사용자 없음")
+    void testHasUserGrade_Fail_UserNotFound() {
+        // given
+        Long invalidUserId = 99999L;
+
+        // when & then
+        assertThatThrownBy(() -> userService.hasUserGrade(invalidUserId))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("User not found with id: " + invalidUserId);
+    }
+
+    @Test
+    @DisplayName("전체 플로우 테스트_사용자 생성부터 삭제까지")
+    void testFullFlow_CreateToDelete() {
+        // 1. 사용자 생성
+        User newUser = createTestUser(
+                "newuser@example.com",
+                "새사용자",
+                UserRole.USER,
+                "987654321",
+                null,
+                null,
+                null
+        );
+
+        // 2. 사용자 정보 조회
+        UserResponse userInfo = userService.getUserInfo(newUser.getId());
+        assertThat(userInfo.email()).isEqualTo("newuser@example.com");
+
+        // 3. 사용자 정보 수정
+        UpdateUserRequest updateRequest = new UpdateUserRequest(
+                "수정된사용자",
+                "010-1111-2222",
+                LocalDate.of(2000, 1, 1),
+                "부산시 해운대구"
+        );
+        UserResponse updatedInfo = userService.updateUserInfo(
+                newUser.getId(),
+                updateRequest,
+                Optional.empty()
+        );
+        assertThat(updatedInfo.name()).isEqualTo("수정된사용자");
+
+        // 4. 등급 설정
+        newUser.setGrade(testGrade);
+        newUser = userRepository.save(newUser);
+
+        // 5. 등급 정보 조회
+        Optional<Grade> grade = userService.getUserGrade(newUser.getId());
+        assertThat(grade).isPresent();
+        assertThat(userService.getUserGradeName(newUser.getId())).isEqualTo(testGrade.getGrade());
+        assertThat(userService.hasUserGrade(newUser.getId())).isTrue();
+
+        // 6. 역할 변경
+        UpdateUserRoleRequest roleRequest = new UpdateUserRoleRequest(UserRole.SELLER);
+        UserResponse roleUpdated = userService.updateUserRole(newUser.getId(), roleRequest);
+        assertThat(roleUpdated.role()).isEqualTo(UserRole.SELLER);
+
+        // 7. 사용자 삭제
+        userService.deleteUser(newUser.getId());
+        Optional<User> deletedUser = userRepository.findById(newUser.getId());
+        assertThat(deletedUser).isEmpty();
+    }
+
+    /**
+     * 테스트용 사용자 생성 헬퍼 메서드
+     * 
+     * @param email 이메일
+     * @param name 이름
+     * @param role 역할
+     * @param providerId Provider ID
+     * @param phoneNumber 핸드폰 번호 (선택)
+     * @param address 주소 (선택)
+     * @param birthDate 생년월일 (선택)
+     * @return 생성된 User 엔티티
+     */
+    private User createTestUser(
+            String email,
+            String name,
+            UserRole role,
+            String providerId,
+            String phoneNumber,
+            String address,
+            LocalDate birthDate
+    ) {
+        User user = User.builder()
+                .email(email)
+                .name(name)
+                .role(role)
+                .provider(OAuth2Provider.GOOGLE)
+                .providerId(providerId)
+                .phoneNumber(phoneNumber)
+                .address(address)
+                .birthDate(birthDate)
+                .build();
+        return userRepository.save(user);
+    }
+}
+

--- a/src/test/java/com/homesweet/homesweetback/domain/auth/service/UserServiceIntegrationTest.java
+++ b/src/test/java/com/homesweet/homesweetback/domain/auth/service/UserServiceIntegrationTest.java
@@ -20,6 +20,8 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.homesweet.homesweetback.common.exception.BusinessException;
+import com.homesweet.homesweetback.common.exception.ErrorCode;
 import com.homesweet.homesweetback.common.s3.ImageUploader;
 import com.homesweet.homesweetback.domain.auth.dto.UpdateUserRequest;
 import com.homesweet.homesweetback.domain.auth.dto.UpdateUserRoleRequest;
@@ -105,9 +107,9 @@ class UserServiceIntegrationTest {
 
         // when & then
         assertThatThrownBy(() -> userService.getUserInfo(invalidUserId))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("User not found with id: " + invalidUserId);
-    }
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
+    }       
 
     @Test
     @DisplayName("updateUserInfo() 테스트_성공_이미지 없음")
@@ -222,8 +224,8 @@ class UserServiceIntegrationTest {
                 request,
                 Optional.empty()
         ))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("User not found with id: " + invalidUserId);
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
     }
 
     @Test
@@ -243,8 +245,8 @@ class UserServiceIntegrationTest {
                 request,
                 Optional.empty()
         ))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("올바른 핸드폰 번호 형식이 아닙니다");
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.INVALID_PHONE_NUMBER_FORMAT.getMessage());
     }
 
     @Test
@@ -269,8 +271,8 @@ class UserServiceIntegrationTest {
 
         // when & then
         assertThatThrownBy(() -> userService.deleteUser(invalidUserId))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("User not found with id: " + invalidUserId);
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
     }
 
     @Test
@@ -302,8 +304,8 @@ class UserServiceIntegrationTest {
 
         // when & then
         assertThatThrownBy(() -> userService.updateUserRole(invalidUserId, request))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("User not found with id: " + invalidUserId);
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
     }
 
     @Test
@@ -340,8 +342,8 @@ class UserServiceIntegrationTest {
 
         // when & then
         assertThatThrownBy(() -> userService.getUserGrade(invalidUserId))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("User not found with id: " + invalidUserId);
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
     }
 
     @Test
@@ -376,8 +378,8 @@ class UserServiceIntegrationTest {
 
         // when & then
         assertThatThrownBy(() -> userService.getUserGradeName(invalidUserId))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("User not found with id: " + invalidUserId);
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
     }
 
     @Test
@@ -412,8 +414,8 @@ class UserServiceIntegrationTest {
 
         // when & then
         assertThatThrownBy(() -> userService.getUserFeeRate(invalidUserId))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("User not found with id: " + invalidUserId);
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
     }
 
     @Test
@@ -448,8 +450,8 @@ class UserServiceIntegrationTest {
 
         // when & then
         assertThatThrownBy(() -> userService.hasUserGrade(invalidUserId))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("User not found with id: " + invalidUserId);
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
     }
 
     @Test

--- a/src/test/java/com/homesweet/homesweetback/domain/auth/service/UserServiceTest.java
+++ b/src/test/java/com/homesweet/homesweetback/domain/auth/service/UserServiceTest.java
@@ -1,0 +1,520 @@
+package com.homesweet.homesweetback.domain.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.homesweet.homesweetback.common.s3.ImageUploader;
+import com.homesweet.homesweetback.domain.auth.dto.UpdateUserRequest;
+import com.homesweet.homesweetback.domain.auth.dto.UpdateUserRoleRequest;
+import com.homesweet.homesweetback.domain.auth.dto.UserResponse;
+import com.homesweet.homesweetback.domain.auth.entity.OAuth2Provider;
+import com.homesweet.homesweetback.domain.auth.entity.User;
+import com.homesweet.homesweetback.domain.auth.entity.UserRole;
+import com.homesweet.homesweetback.domain.auth.repository.UserRepository;
+import com.homesweet.homesweetback.domain.grade.entity.Grade;
+import com.homesweet.homesweetback.domain.grade.repository.GradeRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserService 테스트")
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ImageUploader imageUploader;
+
+    @Mock
+    private GradeRepository gradeRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    @DisplayName("getUserInfo() 메서드 테스트_성공")
+    void testGetUserInfo_Success() {
+        // given
+        Long userId = 1L;
+        User user = createTestUser(userId, UserRole.USER);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        // when
+        UserResponse response = userService.getUserInfo(userId);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.id()).isEqualTo(userId);
+        assertThat(response.email()).isEqualTo("test@test.com");
+        assertThat(response.name()).isEqualTo("test");
+        assertThat(response.role()).isEqualTo(UserRole.USER);
+        verify(userRepository, times(1)).findById(userId);
+    }
+
+    @Test
+    @DisplayName("getUserInfo() 메서드 테스트_실패_사용자 없음")
+    void testGetUserInfo_Fail_UserNotFound() {
+        // given
+        Long userId = 999L;
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.getUserInfo(userId))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("User not found with id: " + userId);
+        verify(userRepository, times(1)).findById(userId);
+    }
+
+    @Test
+    @DisplayName("updateUserInfo() 메서드 테스트_성공_이미지 없음")
+    void testUpdateUserInfo_Success_WithoutImage() {
+        // given
+        Long userId = 1L;
+        User user = createTestUser(userId, UserRole.USER);
+        UpdateUserRequest request = new UpdateUserRequest(
+                "새이름",
+                "010-1234-5678",
+                LocalDate.of(1990, 1, 1),
+                "서울시 강남구"
+        );
+        Optional<MultipartFile> profileImage = Optional.empty();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(userRepository.save(any(User.class))).willReturn(user);
+
+        // when
+        UserResponse response = userService.updateUserInfo(userId, request, profileImage);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.name()).isEqualTo("새이름");
+        assertThat(response.phoneNumber()).isEqualTo("010-1234-5678");
+        assertThat(response.birthDate()).isEqualTo(LocalDate.of(1990, 1, 1));
+        assertThat(response.address()).isEqualTo("서울시 강남구");
+        verify(userRepository, times(1)).findById(userId);
+        verify(userRepository, times(1)).save(user);
+        verify(imageUploader, never()).delete(anyString());
+        verify(imageUploader, never()).upload(any(MultipartFile.class), anyString());
+    }
+
+    @Test
+    @DisplayName("updateUserInfo() 메서드 테스트_성공_이미지 있음")
+    void testUpdateUserInfo_Success_WithImage() {
+        // given
+        Long userId = 1L;
+        User user = createTestUser(userId, UserRole.USER);
+        user.setProfileImageUrl("https://old-image-url.com/image.jpg");
+        UpdateUserRequest request = new UpdateUserRequest(
+                "새이름",
+                null,
+                null,
+                null
+        );
+        MultipartFile mockFile = org.mockito.Mockito.mock(MultipartFile.class);
+        Optional<MultipartFile> profileImage = Optional.of(mockFile);
+        String newImageUrl = "https://new-image-url.com/image.jpg";
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        willDoNothing().given(imageUploader).delete(anyString());
+        given(imageUploader.upload(any(MultipartFile.class), anyString())).willReturn(newImageUrl);
+        given(userRepository.save(any(User.class))).willReturn(user);
+
+        // when
+        UserResponse response = userService.updateUserInfo(userId, request, profileImage);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.name()).isEqualTo("새이름");
+        verify(userRepository, times(1)).findById(userId);
+        verify(imageUploader, times(1)).delete("https://old-image-url.com/image.jpg");
+        verify(imageUploader, times(1)).upload(mockFile, "user/profile/" + userId);
+        verify(userRepository, times(1)).save(user);
+    }
+
+    @Test
+    @DisplayName("updateUserInfo() 메서드 테스트_실패_사용자 없음")
+    void testUpdateUserInfo_Fail_UserNotFound() {
+        // given
+        Long userId = 999L;
+        UpdateUserRequest request = new UpdateUserRequest(null, null, null, null);
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.updateUserInfo(userId, request, Optional.empty()))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("User not found with id: " + userId);
+        verify(userRepository, times(1)).findById(userId);
+    }
+
+    @Test
+    @DisplayName("updateUserInfo() 메서드 테스트_실패_핸드폰 번호 형식 오류")
+    void testUpdateUserInfo_Fail_InvalidPhoneNumber() {
+        // given
+        Long userId = 1L;
+        User user = createTestUser(userId, UserRole.USER);
+        UpdateUserRequest request = new UpdateUserRequest(
+                null,
+                "123-456-789", // 잘못된 형식
+                null,
+                null
+        );
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        // when & then
+        assertThatThrownBy(() -> userService.updateUserInfo(userId, request, Optional.empty()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("올바른 핸드폰 번호 형식이 아닙니다");
+        verify(userRepository, times(1)).findById(userId);
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("updateUserInfo() 메서드 테스트_실패_이미지 삭제 실패")
+    void testUpdateUserInfo_Fail_ImageDeleteFailed() {
+        // given
+        Long userId = 1L;
+        User user = createTestUser(userId, UserRole.USER);
+        user.setProfileImageUrl("https://old-image-url.com/image.jpg");
+        UpdateUserRequest request = new UpdateUserRequest(null, null, null, null);
+        MultipartFile mockFile = org.mockito.Mockito.mock(MultipartFile.class);
+        Optional<MultipartFile> profileImage = Optional.of(mockFile);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        willThrow(new RuntimeException("S3 삭제 실패")).given(imageUploader).delete(anyString());
+
+        // when & then
+        assertThatThrownBy(() -> userService.updateUserInfo(userId, request, profileImage))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("프로필 이미지 삭제에 실패했습니다");
+        verify(userRepository, times(1)).findById(userId);
+        verify(imageUploader, times(1)).delete(anyString());
+        verify(imageUploader, never()).upload(any(MultipartFile.class), anyString());
+    }
+
+    @Test
+    @DisplayName("updateUserInfo() 메서드 테스트_실패_이미지 업로드 실패")
+    void testUpdateUserInfo_Fail_ImageUploadFailed() {
+        // given
+        Long userId = 1L;
+        User user = createTestUser(userId, UserRole.USER);
+        user.setProfileImageUrl("https://old-image-url.com/image.jpg");
+        UpdateUserRequest request = new UpdateUserRequest(null, null, null, null);
+        MultipartFile mockFile = org.mockito.Mockito.mock(MultipartFile.class);
+        Optional<MultipartFile> profileImage = Optional.of(mockFile);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        willDoNothing().given(imageUploader).delete(anyString());
+        willThrow(new RuntimeException("S3 업로드 실패")).given(imageUploader).upload(any(MultipartFile.class), anyString());
+
+        // when & then
+        assertThatThrownBy(() -> userService.updateUserInfo(userId, request, profileImage))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("프로필 이미지 업로드에 실패했습니다");
+        verify(userRepository, times(1)).findById(userId);
+        verify(imageUploader, times(1)).delete(anyString());
+        verify(imageUploader, times(1)).upload(any(MultipartFile.class), anyString());
+    }
+
+    @Test
+    @DisplayName("deleteUser() 메서드 테스트_성공")
+    void testDeleteUser_Success() {
+        // given
+        Long userId = 1L;
+        User user = createTestUser(userId, UserRole.USER);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        willDoNothing().given(userRepository).delete(user);
+
+        // when
+        userService.deleteUser(userId);
+
+        // then
+        verify(userRepository, times(1)).findById(userId);
+        verify(userRepository, times(1)).delete(user);
+    }
+
+    @Test
+    @DisplayName("deleteUser() 메서드 테스트_실패_사용자 없음")
+    void testDeleteUser_Fail_UserNotFound() {
+        // given
+        Long userId = 999L;
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.deleteUser(userId))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("User not found with id: " + userId);
+        verify(userRepository, times(1)).findById(userId);
+        verify(userRepository, never()).delete(any(User.class));
+    }
+
+    @Test
+    @DisplayName("updateUserRole() 메서드 테스트_성공")
+    void testUpdateUserRole_Success() {
+        // given
+        Long userId = 1L;
+        User user = createTestUser(userId, UserRole.USER);
+        UpdateUserRoleRequest request = new UpdateUserRoleRequest(UserRole.SELLER);
+        Grade grade = createTestGrade(1, "GOLD", new BigDecimal("5.00"));
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        // ThreadLocalRandom으로 1~5 사이의 랜덤 값이 생성되므로 any()로 처리
+        given(gradeRepository.findById(any(Integer.class))).willReturn(Optional.of(grade));
+        given(userRepository.save(any(User.class))).willReturn(user);
+
+        // when
+        UserResponse response = userService.updateUserRole(userId, request);
+
+        // then
+        assertThat(response).isNotNull();
+        verify(userRepository, times(1)).findById(userId);
+        verify(gradeRepository, times(1)).findById(any(Integer.class));
+        verify(userRepository, times(1)).save(user);
+    }
+
+    @Test
+    @DisplayName("updateUserRole() 메서드 테스트_실패_사용자 없음")
+    void testUpdateUserRole_Fail_UserNotFound() {
+        // given
+        Long userId = 999L;
+        UpdateUserRoleRequest request = new UpdateUserRoleRequest(UserRole.SELLER);
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.updateUserRole(userId, request))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("User not found with id: " + userId);
+        verify(userRepository, times(1)).findById(userId);
+        verify(gradeRepository, never()).findById(any(Integer.class));
+    }
+
+    @Test
+    @DisplayName("getUserGrade() 메서드 테스트_성공_등급 있음")
+    void testGetUserGrade_Success_WithGrade() {
+        // given
+        Long userId = 1L;
+        Grade grade = createTestGrade(1, "GOLD", new BigDecimal("5.00"));
+        User user = createTestUser(userId, UserRole.USER);
+        user.setGrade(grade);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        // when
+        Optional<Grade> result = userService.getUserGrade(userId);
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().getGrade()).isEqualTo("GOLD");
+        verify(userRepository, times(1)).findById(userId);
+    }
+
+    @Test
+    @DisplayName("getUserGrade() 메서드 테스트_성공_등급 없음")
+    void testGetUserGrade_Success_WithoutGrade() {
+        // given
+        Long userId = 1L;
+        User user = createTestUser(userId, UserRole.USER);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        // when
+        Optional<Grade> result = userService.getUserGrade(userId);
+
+        // then
+        assertThat(result).isEmpty();
+        verify(userRepository, times(1)).findById(userId);
+    }
+
+    @Test
+    @DisplayName("getUserGrade() 메서드 테스트_실패_사용자 없음")
+    void testGetUserGrade_Fail_UserNotFound() {
+        // given
+        Long userId = 999L;
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.getUserGrade(userId))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("User not found with id: " + userId);
+        verify(userRepository, times(1)).findById(userId);
+    }
+
+    @Test
+    @DisplayName("getUserGradeName() 메서드 테스트_성공_등급 있음")
+    void testGetUserGradeName_Success_WithGrade() {
+        // given
+        Long userId = 1L;
+        Grade grade = createTestGrade(1, "GOLD", new BigDecimal("5.00"));
+        User user = createTestUser(userId, UserRole.USER);
+        user.setGrade(grade);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        // when
+        String gradeName = userService.getUserGradeName(userId);
+
+        // then
+        assertThat(gradeName).isEqualTo("GOLD");
+        verify(userRepository, times(1)).findById(userId);
+    }
+
+    @Test
+    @DisplayName("getUserGradeName() 메서드 테스트_성공_등급 없음")
+    void testGetUserGradeName_Success_WithoutGrade() {
+        // given
+        Long userId = 1L;
+        User user = createTestUser(userId, UserRole.USER);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        // when
+        String gradeName = userService.getUserGradeName(userId);
+
+        // then
+        assertThat(gradeName).isEqualTo("등급 없음");
+        verify(userRepository, times(1)).findById(userId);
+    }
+
+    @Test
+    @DisplayName("getUserGradeName() 메서드 테스트_실패_사용자 없음")
+    void testGetUserGradeName_Fail_UserNotFound() {
+        // given
+        Long userId = 999L;
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.getUserGradeName(userId))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("User not found with id: " + userId);
+        verify(userRepository, times(1)).findById(userId);
+    }
+
+    @Test
+    @DisplayName("getUserFeeRate() 메서드 테스트_성공_등급 있음")
+    void testGetUserFeeRate_Success_WithGrade() {
+        // given
+        Long userId = 1L;
+        BigDecimal feeRate = new BigDecimal("5.00");
+        Grade grade = createTestGrade(1, "GOLD", feeRate);
+        User user = createTestUser(userId, UserRole.USER);
+        user.setGrade(grade);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        // when
+        BigDecimal result = userService.getUserFeeRate(userId);
+
+        // then
+        assertThat(result).isEqualByComparingTo(feeRate);
+        verify(userRepository, times(1)).findById(userId);
+    }
+
+    @Test
+    @DisplayName("getUserFeeRate() 메서드 테스트_성공_등급 없음")
+    void testGetUserFeeRate_Success_WithoutGrade() {
+        // given
+        Long userId = 1L;
+        User user = createTestUser(userId, UserRole.USER);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        // when
+        BigDecimal result = userService.getUserFeeRate(userId);
+
+        // then
+        assertThat(result).isEqualByComparingTo(BigDecimal.ZERO);
+        verify(userRepository, times(1)).findById(userId);
+    }
+
+    @Test
+    @DisplayName("getUserFeeRate() 메서드 테스트_실패_사용자 없음")
+    void testGetUserFeeRate_Fail_UserNotFound() {
+        // given
+        Long userId = 999L;
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.getUserFeeRate(userId))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("User not found with id: " + userId);
+        verify(userRepository, times(1)).findById(userId);
+    }
+
+    @Test
+    @DisplayName("hasUserGrade() 메서드 테스트_성공_등급 있음")
+    void testHasUserGrade_Success_WithGrade() {
+        // given
+        Long userId = 1L;
+        Grade grade = createTestGrade(1, "GOLD", new BigDecimal("5.00"));
+        User user = createTestUser(userId, UserRole.USER);
+        user.setGrade(grade);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        // when
+        boolean result = userService.hasUserGrade(userId);
+
+        // then
+        assertThat(result).isTrue();
+        verify(userRepository, times(1)).findById(userId);
+    }
+
+    @Test
+    @DisplayName("hasUserGrade() 메서드 테스트_성공_등급 없음")
+    void testHasUserGrade_Success_WithoutGrade() {
+        // given
+        Long userId = 1L;
+        User user = createTestUser(userId, UserRole.USER);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        // when
+        boolean result = userService.hasUserGrade(userId);
+
+        // then
+        assertThat(result).isFalse();
+        verify(userRepository, times(1)).findById(userId);
+    }
+
+    @Test
+    @DisplayName("hasUserGrade() 메서드 테스트_실패_사용자 없음")
+    void testHasUserGrade_Fail_UserNotFound() {
+        // given
+        Long userId = 999L;
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.hasUserGrade(userId))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("User not found with id: " + userId);
+        verify(userRepository, times(1)).findById(userId);
+    }
+
+    private User createTestUser(Long userId, UserRole role) {
+        User user = User.builder()
+                .email("test@test.com")
+                .name("test")
+                .role(role)
+                .provider(OAuth2Provider.GOOGLE)
+                .providerId("123456789")
+                .build();
+        user.setId(userId);
+        return user;
+    }
+
+    private Grade createTestGrade(Integer gradeId, String gradeName, BigDecimal feeRate) {
+        // AllArgsConstructor를 사용하여 gradeId 포함
+        return new Grade(gradeId, gradeName, feeRate);
+    }
+}
+

--- a/src/test/java/com/homesweet/homesweetback/domain/auth/service/UserServiceTest.java
+++ b/src/test/java/com/homesweet/homesweetback/domain/auth/service/UserServiceTest.java
@@ -23,6 +23,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.homesweet.homesweetback.common.exception.BusinessException;
+import com.homesweet.homesweetback.common.exception.ErrorCode;
 import com.homesweet.homesweetback.common.s3.ImageUploader;
 import com.homesweet.homesweetback.domain.auth.dto.UpdateUserRequest;
 import com.homesweet.homesweetback.domain.auth.dto.UpdateUserRoleRequest;
@@ -49,6 +51,39 @@ class UserServiceTest {
 
     @InjectMocks
     private UserService userService;
+
+    @Test
+    @DisplayName("getUserById() 메서드 테스트_성공")
+    void testGetUserById_Success() {
+        // given
+        Long userId = 1L;
+        User user = createTestUser(userId, UserRole.USER);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        // when
+        User result = userService.getUserById(userId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(userId);
+        assertThat(result.getEmail()).isEqualTo("test@test.com");
+        assertThat(result.getName()).isEqualTo("test");
+        assertThat(result.getRole()).isEqualTo(UserRole.USER);
+    }
+
+    @Test
+    @DisplayName("getUserById() 메서드 테스트_실패_사용자 없음")
+    void testGetUserById_Fail_UserNotFound() {
+        // given
+        Long userId = 999L;
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.getUserById(userId))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
+        verify(userRepository, times(1)).findById(userId);
+    }
 
     @Test
     @DisplayName("getUserInfo() 메서드 테스트_성공")
@@ -79,8 +114,8 @@ class UserServiceTest {
 
         // when & then
         assertThatThrownBy(() -> userService.getUserInfo(userId))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("User not found with id: " + userId);
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
         verify(userRepository, times(1)).findById(userId);
     }
 
@@ -160,8 +195,8 @@ class UserServiceTest {
 
         // when & then
         assertThatThrownBy(() -> userService.updateUserInfo(userId, request, Optional.empty()))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("User not found with id: " + userId);
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
         verify(userRepository, times(1)).findById(userId);
     }
 
@@ -181,8 +216,8 @@ class UserServiceTest {
 
         // when & then
         assertThatThrownBy(() -> userService.updateUserInfo(userId, request, Optional.empty()))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("올바른 핸드폰 번호 형식이 아닙니다");
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.INVALID_PHONE_NUMBER_FORMAT.getMessage());
         verify(userRepository, times(1)).findById(userId);
         verify(userRepository, never()).save(any(User.class));
     }
@@ -203,8 +238,8 @@ class UserServiceTest {
 
         // when & then
         assertThatThrownBy(() -> userService.updateUserInfo(userId, request, profileImage))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("프로필 이미지 삭제에 실패했습니다");
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.FILE_STREAM_ERROR.getMessage());
         verify(userRepository, times(1)).findById(userId);
         verify(imageUploader, times(1)).delete(anyString());
         verify(imageUploader, never()).upload(any(MultipartFile.class), anyString());
@@ -227,8 +262,8 @@ class UserServiceTest {
 
         // when & then
         assertThatThrownBy(() -> userService.updateUserInfo(userId, request, profileImage))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("프로필 이미지 업로드에 실패했습니다");
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.FILE_STREAM_ERROR.getMessage());
         verify(userRepository, times(1)).findById(userId);
         verify(imageUploader, times(1)).delete(anyString());
         verify(imageUploader, times(1)).upload(any(MultipartFile.class), anyString());
@@ -260,8 +295,8 @@ class UserServiceTest {
 
         // when & then
         assertThatThrownBy(() -> userService.deleteUser(userId))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("User not found with id: " + userId);
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
         verify(userRepository, times(1)).findById(userId);
         verify(userRepository, never()).delete(any(User.class));
     }
@@ -300,8 +335,8 @@ class UserServiceTest {
 
         // when & then
         assertThatThrownBy(() -> userService.updateUserRole(userId, request))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("User not found with id: " + userId);
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
         verify(userRepository, times(1)).findById(userId);
         verify(gradeRepository, never()).findById(any(Integer.class));
     }
@@ -350,8 +385,8 @@ class UserServiceTest {
 
         // when & then
         assertThatThrownBy(() -> userService.getUserGrade(userId))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("User not found with id: " + userId);
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
         verify(userRepository, times(1)).findById(userId);
     }
 
@@ -398,8 +433,8 @@ class UserServiceTest {
 
         // when & then
         assertThatThrownBy(() -> userService.getUserGradeName(userId))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("User not found with id: " + userId);
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
         verify(userRepository, times(1)).findById(userId);
     }
 
@@ -447,8 +482,8 @@ class UserServiceTest {
 
         // when & then
         assertThatThrownBy(() -> userService.getUserFeeRate(userId))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("User not found with id: " + userId);
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
         verify(userRepository, times(1)).findById(userId);
     }
 
@@ -495,8 +530,8 @@ class UserServiceTest {
 
         // when & then
         assertThatThrownBy(() -> userService.hasUserGrade(userId))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("User not found with id: " + userId);
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
         verify(userRepository, times(1)).findById(userId);
     }
 


### PR DESCRIPTION
## 구현 내용
<!-- 구현한 기능에 대한 간략한 설명을 작성해주세요 -->

User 및 인증 기능 리팩토링 및 테스트 코드 작성, Notification 비동기 처리 개선, Product/Community/Chat/Order 등 다양한 도메인의 테스트 코드 추가

### 주요 변경사항

#### 1. User 및 인증 기능 리팩토링 및 테스트 작성
- **AuthService 리팩토링**
  - 인증 로직 개선 및 코드 정리
  - 에러 처리 강화
- **테스트 코드 작성**
  - `AuthServiceTest`: 단위 테스트 (423줄)
  - `AuthServiceIntegrationTest`: 통합 테스트 (559줄)
  - `UserServiceTest`: 단위 테스트 (520줄)
  - `UserServiceIntegrationTest`: 통합 테스트 (542줄)
  - `UserRepositoryTest`: 리포지토리 테스트 (136줄)
  - `RefreshTokenRepositoryTest`: 리프레시 토큰 테스트 (162줄)
  - 엔티티 테스트: `UserTest`, `OAuth2ProviderTest`, `OAuth2UserPrincipalTest`, `UserRoleTest'

## 테스트 완료 사항
<!-- 테스트한 항목에 체크(x)해주세요 -->
- [ x ] 단위 테스트
- [ x ] 통합 테스트
- [ ] API 테스트 (Swagger/Postman 등)
- [ ] 기타 테스트

## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
closes #136 